### PR TITLE
Fixed #159 multibytes problem in NINJAM chat.

### DIFF
--- a/Client/src/ninjam/protocol/ClientMessages.cpp
+++ b/Client/src/ninjam/protocol/ClientMessages.cpp
@@ -19,7 +19,7 @@ void ClientMessage::serializeString(const QString &str, QDataStream &stream){
     //serializeByteArray(QByteArray(str.toStdString().c_str()), stream);
 
     //serializeByteArray(str.toUtf8(), stream);
-    QByteArray dataArray = str.toLatin1();
+    QByteArray dataArray = str.toUtf8();
     stream.writeRawData(dataArray.data(), dataArray.size());
 
     stream << quint8('\0'); // NUL TERMINATED
@@ -183,7 +183,7 @@ void ClientSetUserMask::printDebug(QDebug dbg) const
 ChatMessage::ChatMessage(QString text)
     : ClientMessage(0xc0, 0), text(text), command("MSG")
 {
-    payload = text.toLatin1().size() + 1 + command.length() + 1;
+    payload = text.toUtf8().size() + 1 + command.length() + 1;
 }
 
 void ChatMessage::serializeTo(QByteArray &buffer){

--- a/Client/src/ninjam/protocol/ServerMessageParser.cpp
+++ b/Client/src/ninjam/protocol/ServerMessageParser.cpp
@@ -152,7 +152,7 @@ const ServerMessage& ServerMessageParser::parseChatMessage(QDataStream &stream, 
     quint32 consumedBytes = 0;
 
     int commandStringSize = getStringSize(data, payloadLenght);
-    QString command = QString::fromLatin1(data, commandStringSize-1);//remove the NULL terminator (2 bytes - utf-8)
+    QString command = QString::fromUtf8(data, commandStringSize-1);//remove the NULL terminator (2 bytes - utf-8)
     consumedBytes += commandStringSize;
 
 
@@ -160,7 +160,7 @@ const ServerMessage& ServerMessageParser::parseChatMessage(QDataStream &stream, 
     QStringList arguments;
     while(consumedBytes < payloadLenght && parsedArgs < 4){
         int argStringSize = getStringSize(data + consumedBytes, payloadLenght - consumedBytes);
-        QString arg = QString::fromLatin1(data + consumedBytes, argStringSize-1);
+        QString arg = QString::fromUtf8(data + consumedBytes, argStringSize-1);
         arguments.append(arg);
         consumedBytes += argStringSize;
         parsedArgs++;


### PR DESCRIPTION
resolve #159

NOTE: This patch does not fix another multibyte problem.
which official windows clients send chat message with their
native encoding. They are another issue.