### PR TITLE
Fix QWaitCondition warning by separate thread

### DIFF
--- a/Client/src/NinjamController.cpp
+++ b/Client/src/NinjamController.cpp
@@ -242,7 +242,11 @@ void NinjamController::process(const Audio::SamplesBuffer &in, Audio::SamplesBuf
                             mainController->mixGroupedInputs(groupIndex, inputMixBuffer);
 
                             //encoding is running in another thread to avoid slow down the audio thread
-                            encodingWorker->addSamplesToEncode( inputMixBuffer, groupIndex, isFirstPart, isLastPart);
+                            QMetaObject::invokeMethod(encodingWorker, "addSamplesToEncode", Qt::QueuedConnection,
+                                                      Q_ARG(const Audio::SamplesBuffer, inputMixBuffer),
+                                                      Q_ARG(quint8, groupIndex),
+                                                      Q_ARG(bool, isFirstPart),
+                                                      Q_ARG(bool, isLastPart));
                         }
                     }
                 }

--- a/Client/src/NinjamController.cpp
+++ b/Client/src/NinjamController.cpp
@@ -21,94 +21,62 @@
 
 #include "audio/samplesbufferrecorder.h"
 #include "Utils.h"
-#include <QWaitCondition>
 #include "log/logging.h"
 
 
 using namespace Controller;
 
 //+++++++++++++  ENCODING THREAD  +++++++++++++
-class NinjamController::EncodingThread : public QThread{//TODO: use better thread approach, avoid inheritance form QThread
-public:
-    EncodingThread(NinjamController* controller)
-        :stopRequested(false), controller(controller){
-        qCDebug(jtNinjamCore) << "Starting Encoding Thread";
-        start();
+
+EncodingWorker::EncodingWorker(NinjamController *controller, QObject *parent)
+    : QObject(parent), stopRequested(false), controller(controller)
+{
+}
+
+void EncodingWorker::addSamplesToEncode(const Audio::SamplesBuffer& samplesToEncode, quint8 channelIndex, bool isFirstPart, bool isLastPart){
+    //qCDebug(jtNinjamCore) << "Adding samples to encode";
+    QMutexLocker locker(&mutex);
+    chunksToEncode.append(new EncodingChunk(samplesToEncode, channelIndex, isFirstPart, isLastPart));
+    //this method is called by Qt main thread (the producer thread).
+    hasAvailableChunksToEncode.wakeAll();//wakeup the encoding thread (consumer thread)
+}
+
+void EncodingWorker::stop(){
+    if(!stopRequested){
+        //QMutexLocker locker(&mutex);
+        stopRequested = true;
+        hasAvailableChunksToEncode.wakeAll();
+        qCDebug(jtNinjamCore) << "Stopping Encoding Thread";
     }
+}
 
-    ~EncodingThread(){
-        stop();
-    }
-
-    void addSamplesToEncode(const Audio::SamplesBuffer& samplesToEncode, quint8 channelIndex, bool isFirstPart, bool isLastPart){
-        //qCDebug(jtNinjamCore) << "Adding samples to encode";
-        QMutexLocker locker(&mutex);
-        chunksToEncode.append(new EncodingChunk(samplesToEncode, channelIndex, isFirstPart, isLastPart));
-        //this method is called by Qt main thread (the producer thread).
-        hasAvailableChunksToEncode.wakeAll();//wakeup the encoding thread (consumer thread)
-
-    }
-
-    void stop(){
-        if(!stopRequested){
-            //QMutexLocker locker(&mutex);
-            stopRequested = true;
-            hasAvailableChunksToEncode.wakeAll();
-            qCDebug(jtNinjamCore) << "Stopping Encoding Thread";
+void EncodingWorker::run(){
+    while(!stopRequested){
+        mutex.lock();
+        if(chunksToEncode.isEmpty()){
+            hasAvailableChunksToEncode.wait(&mutex);
         }
-    }
-
-protected:
-    void run(){
-        while(!stopRequested){
-            mutex.lock();
-            if(chunksToEncode.isEmpty()){
-                hasAvailableChunksToEncode.wait(&mutex);
-            }
-            if(stopRequested){
-                mutex.unlock();
-                break;
-            }
-            EncodingChunk* chunk = chunksToEncode.first();
-            chunksToEncode.removeFirst();
+        if(stopRequested){
             mutex.unlock();
-			if (chunk){
-                QByteArray encodedBytes( controller->encode(chunk->buffer, chunk->channelIndex));
-                if (chunk->lastPart){
-                    encodedBytes.append( controller->encodeLastPartOfInterval(chunk->channelIndex));
-                }
-
-                if(!encodedBytes.isEmpty()){
-                    emit controller->encodedAudioAvailableToSend(encodedBytes, chunk->channelIndex, chunk->firstPart, chunk->lastPart);
-                }
-				delete chunk;
-			}
-
+            break;
         }
-        qCDebug(jtNinjamCore) << "Encoding thread stopped!";
+        EncodingChunk* chunk = chunksToEncode.first();
+        chunksToEncode.removeFirst();
+        mutex.unlock();
+        if (chunk){
+            QByteArray encodedBytes( controller->encode(chunk->buffer, chunk->channelIndex));
+            if (chunk->lastPart){
+                encodedBytes.append( controller->encodeLastPartOfInterval(chunk->channelIndex));
+            }
+
+            if(!encodedBytes.isEmpty()){
+                emit controller->encodedAudioAvailableToSend(encodedBytes, chunk->channelIndex, chunk->firstPart, chunk->lastPart);
+            }
+            delete chunk;
+        }
     }
-
-private:
-    class EncodingChunk{
-    public:
-        EncodingChunk(const Audio::SamplesBuffer& buffer, quint8 channelIndex, bool firstPart, bool lastPart)
-            :buffer(buffer), channelIndex(channelIndex), firstPart(firstPart), lastPart(lastPart ) {
-
-        }
-
-        Audio::SamplesBuffer buffer;
-        quint8 channelIndex;
-        bool firstPart;
-        bool lastPart;
-    };
-
-    QList<EncodingChunk*> chunksToEncode;
-    QMutex mutex;
-    volatile bool stopRequested;
-    NinjamController* controller;
-    QWaitCondition hasAvailableChunksToEncode;
-
-};
+    qCDebug(jtNinjamCore) << "Encoding thread stopped!";
+}
 
 //+++++++++++++++++ Nested classes to handle schedulable events ++++++++++++++++
 
@@ -187,6 +155,7 @@ NinjamController::NinjamController(Controller::MainController* mainController)
     mutex(QMutex::Recursive),
     encodersMutex(QMutex::Recursive),
     encodingThread(nullptr),
+    encodingWorker(nullptr),
     preparedForTransmit(false),
     waitingIntervals(0)//waiting for start transmit
 {
@@ -273,7 +242,7 @@ void NinjamController::process(const Audio::SamplesBuffer &in, Audio::SamplesBuf
                             mainController->mixGroupedInputs(groupIndex, inputMixBuffer);
 
                             //encoding is running in another thread to avoid slow down the audio thread
-                            encodingThread->addSamplesToEncode( inputMixBuffer, groupIndex, isFirstPart, isLastPart);
+                            encodingWorker->addSamplesToEncode( inputMixBuffer, groupIndex, isFirstPart, isLastPart);
                         }
                     }
                 }
@@ -315,9 +284,11 @@ void NinjamController::stop(bool emitDisconnectedingSignal){
     }
 
     if(encodingThread){
-        encodingThread->stop();
+        encodingWorker->stop();
         encodingThread->wait();//wait the encoding thread to finish
+        delete encodingWorker;
         delete encodingThread;
+        encodingWorker = nullptr;
         encodingThread = nullptr;
     }
 
@@ -377,8 +348,11 @@ void NinjamController::start(const Ninjam::Server& server, QMap<int, bool> chann
     processScheduledChanges();
 
     if(!running){
-
-        encodingThread = new NinjamController::EncodingThread(this);
+        encodingThread = new QThread(this);
+        encodingWorker = new EncodingWorker(this, this);
+        encodingWorker->moveToThread(encodingThread);
+        QObject::connect(encodingThread, SIGNAL(started()), encodingWorker, SLOT(run()));
+        encodingThread->start();
 
         //add a sine wave generator as input to test audio transmission
         //mainController->addInputTrackNode(new Audio::LocalInputTestStreamer(440, mainController->getAudioDriverSampleRate()));


### PR DESCRIPTION
## Summary of this commit changes:

- Move inner classes in cpp files to header file.
  Because, QObject require to include "moc" file.
- Separate worker class.
- remove the destructor

----

- https://blog.qt.io/blog/2010/06/17/youre-doing-it-wrong/
  This article explains the confuse part of QThread and  new Qt5 thread

----

This is a WIP PR (Work In Progress Pull Request) practice with real patch.

Note to Assignee
Please do not merge until those tasks are consumed.
When the time to go merge, I will remove [WIP] on the title.

- [x] thread context
  addSamplesToEncode method is a just trigger to input data. but may be blocked.
  does it need to be thread context by QMetaObject::invokeMethod, or can be in main thread.
  I have a commit on local (not pushed to remote yet)

- [x] I am not testing the side effects by this changes.

- [x] Is it safe to remove the destructor?
      Not sure at this moment, so need to debug more info.

      thread and worker both inherits QObject, they can be put on QObject heap
      usually no need manual delete code. if there is same life span object,
      he can become the parent(parent node of the heap, not super-class)

- [x] @elieserdejesus you can put Milestone to this PR
      I choose this topic because this was commented in TODO
      and priority can be low, users may not notice this warning.
      not next version but near future (not so big task).

     I have sub-topic about version. Qt has version <major>.<minor>.<patch>
     when Jamtaba increment the middle version?

- [x] review codes, small matters

     e.g. I move class to header, now the NinjamController.h has several classes
     they should be separate files, but I was not sure where should I put.
     namespace and path of file.

     this project does not have coding style rule. (I mean here, not documented on wiki)
     I believe following Qt's official is the best way, because Qt has pre-process by qmake.

     If you have own idea/experience,
     but It is hard task to write the document from scratch, so following standard is easy way,
     use one of standard style and customize, write the difference as project local rule.

  - QtCreator has coding style support, she looks style for code analysis.
    you don't need to care this writing time, just auto format before commit.
  - ambiguous is confuse for contributors.
    having coding guide make them feel easy to make a patch.

- [x] no Unit tests
  This is a big topic, this PR will not have unit tests.
  Maybe small example code to show what was problem and what this patch fixed.

  @elieserdejesus we had talked about CI before. I know this is also has initial cost, tho.
  if JamTaba use open source license with public repo
  it's a chance to use those service.
  I am not sure about VST SDK which another license.
  but at least some parts can be test as sub modules.


I know this post has several sub topics which not usually talked in PR.
these are should discuss other thread or chat, this time I just leave as the memo.

Now this is a beginning stage, I may put more tasks when I noticed.