### PR TITLE
Sanitize cache data

### DIFF
--- a/Client/src/gui/NinjamRoomWindow.cpp
+++ b/Client/src/gui/NinjamRoomWindow.cpp
@@ -295,7 +295,7 @@ void NinjamRoomWindow::on_channelAdded(Ninjam::User user, Ninjam::UserChannel ch
 
     //remembering user track controls (gain, mute, pan, boost)
     UsersDataCache* cache = mainController->getUsersDataCache();
-    CacheEntry cacheEntry = cache->getUserCacheEntry(user.getIp(), user.getName(), (int)channel.getIndex());//a empty/default cacheEntry is returned if the user is not cached
+    CacheEntry cacheEntry = cache->getUserCacheEntry(user.getIp(), user.getName(), static_cast<quint8>(channel.getIndex()));//a empty/default cacheEntry is returned if the user is not cached
 
     if(!trackGroups.contains(user.getFullName())){//first channel from this user?
         QString channelName = channel.getName();

--- a/Client/src/persistence/UsersDataCache.cpp
+++ b/Client/src/persistence/UsersDataCache.cpp
@@ -122,7 +122,7 @@ UsersDataCache::~UsersDataCache(){
     }
 }
 
-CacheEntry UsersDataCache::getUserCacheEntry(QString userIp, QString userName, quint8 channelID){
+CacheEntry UsersDataCache::getUserCacheEntry(const QString& userIp, const QString& userName, quint8 channelID){
     QString userUniqueKey = getUserUniqueKey(userIp, userName, channelID);
     if(cacheEntries.contains(userUniqueKey)){
         return cacheEntries[userUniqueKey];

--- a/Client/src/persistence/UsersDataCache.cpp
+++ b/Client/src/persistence/UsersDataCache.cpp
@@ -49,9 +49,65 @@ QDataStream & operator>>(QDataStream &stream, CacheEntry &entry)
 
 
 //+++++++++++++++++++++++++++++++++++++++
-CacheEntry::CacheEntry(QString userIp, QString userName, quint8 channelID, bool muted, float gain, float pan, float boost)
-    :userIp(userIp), userName(userName), channelID(channelID), muted(muted), gain(gain), pan(pan), boost(boost){
 
+CacheEntry::CacheEntry(const QString& userIp, const QString& userName, quint8 channelID)
+{
+    setUserIP(userIp);
+    setUserName(userName);
+    setChannelID(channelID);
+    setMuted(DEFAULT_MUTE);
+    setGain(DEFAULT_GAIN);
+    setPan(DEFAULT_PAN);
+    setBoost(DEFAULT_BOOST);
+}
+
+void CacheEntry::setUserIP(const QString& userIp)
+{
+    if (ipPattern.exactMatch(userIp)) {
+        this->userIp = userIp;
+    }
+    else {
+        qCDebug(jtCache) << "invalid ip address: " << userIp;
+    }
+}
+
+void CacheEntry::setUserName(const QString& userName)
+{
+    if (namePattern.exactMatch(userName)) {
+        this->userName = userName;
+    }
+    else {
+        qCDebug(jtCache) << "invalid name: " << userName;
+    }
+}
+
+void CacheEntry::setChannelID(quint8 channelID)
+{
+    this->channelID = channelID;
+}
+
+void CacheEntry::setMuted(bool muted)
+{
+    this->muted = muted;
+}
+
+void CacheEntry::setPan(float pan)
+{
+    this->pan = qBound(PAN_MIN, pan, PAN_MAX);
+
+    if (pan != this->pan) {
+        qCDebug(jtCache) << "pan " << pan << " was out of range";
+    }
+}
+
+void CacheEntry::setBoost(float boost)
+{
+    this->boost = boost;
+}
+
+void CacheEntry::setGain(float gain)
+{
+    this->gain = gain;
 }
 
 UsersDataCache::UsersDataCache()

--- a/Client/src/persistence/UsersDataCache.cpp
+++ b/Client/src/persistence/UsersDataCache.cpp
@@ -147,6 +147,7 @@ void UsersDataCache::loadCacheEntriesFromFile(){
     QFile cacheFile(cacheDir.absoluteFilePath(CACHE_FILE_NAME));
     if(cacheFile.open(QFile::ReadOnly)){
         QDataStream stream(&cacheFile);
+        stream.skipRawData(12); // skip header
         stream >> cacheEntries;
     }
     qCDebug(jtCache) << "Tracks cache items loaded from file: " << cacheEntries.size();
@@ -160,7 +161,15 @@ void UsersDataCache::writeCacheEntriesToFile(){
     if(cacheFile.open(QFile::WriteOnly)){
         qCDebug(jtCache) << "Tracks cache file opened to write.";
         QDataStream stream(&cacheFile);
+
+        // TODO: move thise to header. this is a qucik dirty implementation
+        quint32 signature = 0x4a544232; // "JTB2"
+        quint32 revision = 1;
+        quint32 offset = 12; // sizeof(signature) + sizeof(revision) + sizeof(offset)
+        stream << signature << revision << offset;
+
         stream << cacheEntries;
+
         qCDebug(jtCache) << cacheEntries.size() << " items stored in tracks cache file!";
     }
     else{

--- a/Client/src/persistence/UsersDataCache.cpp
+++ b/Client/src/persistence/UsersDataCache.cpp
@@ -7,6 +7,12 @@
 
 using namespace Persistence;
 
+const bool CacheEntry::DEFAULT_MUTED = false;
+const float CacheEntry::DEFAULT_GAIN = 1.0f;
+const float CacheEntry::DEFAULT_PAN = 0.0f;
+const float CacheEntry::DEFAULT_BOOST = 1.0f;
+const float CacheEntry::PAN_MAX = 4.0f;
+const float CacheEntry::PAN_MIN = -4.0f;
 
 // well formed address is an acceptable.
 // no need to validate the number within 8 bits.
@@ -55,7 +61,7 @@ CacheEntry::CacheEntry(const QString& userIp, const QString& userName, quint8 ch
     setUserIP(userIp);
     setUserName(userName);
     setChannelID(channelID);
-    setMuted(DEFAULT_MUTE);
+    setMuted(DEFAULT_MUTED);
     setGain(DEFAULT_GAIN);
     setPan(DEFAULT_PAN);
     setBoost(DEFAULT_BOOST);

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -33,13 +33,13 @@ public:
     inline QString getUserName() const{ return userName; }
     inline quint8 getChannelID() const{ return channelID; }
 
-    inline void setUserIP(const QString& userIp);
-    inline void setUserName(const QString& userName);
-    inline void setChannelID(quint8 channelID);
-    inline void setMuted(bool muted);
-    inline void setPan(float pan);
-    inline void setBoost(float boost);
-    inline void setGain(float gain);
+    void setUserIP(const QString& userIp);
+    void setUserName(const QString& userName);
+    void setChannelID(quint8 channelID);
+    void setMuted(bool muted);
+    void setPan(float pan);
+    void setBoost(float boost);
+    void setGain(float gain);
 
     static QRegExp ipPattern;
     static QRegExp namePattern;

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -13,12 +13,6 @@
 
 namespace Persistence {
 
-constexpr int DEFAULT_MUTE = false;
-constexpr float DEFAULT_GAIN = 1.0f;
-constexpr float DEFAULT_PAN = 0.0f;
-constexpr float DEFAULT_BOOST = 1.0f;
-constexpr float PAN_MAX = 4.0f;
-constexpr float PAN_MIN = -4.0f;
 
 class CacheEntry{//cache entries are per channel, not per user.
 public:
@@ -43,6 +37,13 @@ public:
 
     static QRegExp ipPattern;
     static QRegExp namePattern;
+
+    static const bool DEFAULT_MUTED;
+    static const float DEFAULT_GAIN;
+    static const float DEFAULT_PAN;
+    static const float DEFAULT_BOOST;
+    static const float PAN_MAX;
+    static const float PAN_MIN;
 private:
     QString userIp;
     QString userName;

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -1,8 +1,10 @@
 #ifndef USERSDATACACHE_H
 #define USERSDATACACHE_H
 
+
 #include <QString>
 #include <QMap>
+#include <QRegExp>
 
 /***
   This class is used to store/remember the users level, pan, mute and boost. When a user enter in the jam
@@ -13,7 +15,7 @@ namespace Persistence {
 
 class CacheEntry{//cache entries are per channel, not per user.
 public:
-    CacheEntry(QString userIp, QString userName, int channelID, bool muted=false, float gain=1.0, float pan=0.0, float boost=1.0);
+    CacheEntry(QString userIp, QString userName, quint8 channelID, bool muted=false, float gain=1.0, float pan=0.0, float boost=1.0);
     CacheEntry(){}//default constructor just to use in QMap without pointers
 
     inline bool isMuted() const{ return muted; }
@@ -22,16 +24,22 @@ public:
     inline float getBoost() const{ return boost; }
     inline QString getUserIP() const{ return userIp; }
     inline QString getUserName() const{ return userName; }
-    inline int getChannelID() const{ return channelID; }
+    inline quint8 getChannelID() const{ return channelID; }
 
+    inline void setUserIP(QString userIp){ this->userIp = userIp; }
+    inline void setUserName(QString userName){ this->userName = userName; }
+    inline void setChannelID(quint8 channelID){ this->channelID = channelID; }
     inline void setMuted(bool muted){ this->muted = muted; }
     inline void setPan(float pan){ this->pan = pan; }
     inline void setBoost(float boost) { this->boost = boost; }
     inline void setGain(float gain){ this->gain = gain; }
+
+    static QRegExp ipPattern;
+    static QRegExp namePattern;
 private:
     QString userIp;
     QString userName;
-    int channelID;
+    quint8 channelID;
     bool muted;
     float gain;//fader level
     float pan;
@@ -45,12 +53,12 @@ class UsersDataCache
 public:
     UsersDataCache();
     ~UsersDataCache();
-    CacheEntry getUserCacheEntry(QString userIp, QString userName, int channelID);//return default values for pan, gain and mute if user is not cached yet
+    CacheEntry getUserCacheEntry(QString userIp, QString userName, quint8 channelID);//return default values for pan, gain and mute if user is not cached yet
     void updateUserCacheEntry(CacheEntry entry);
 private:
     QMap<QString, CacheEntry> cacheEntries;
 
-    static QString getUserUniqueKey(QString userIp, QString userName, int channelID);
+    static QString getUserUniqueKey(const QString& userIp, const QString& userName, quint8 channelID);
 
     void loadCacheEntriesFromFile();
     void writeCacheEntriesToFile();

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -13,10 +13,17 @@
 
 namespace Persistence {
 
+#define DEFAULT_MUTE false
+#define DEFAULT_GAIN 1.0f
+#define DEFAULT_PAN 0.0f
+#define DEFAULT_BOOST 1.0f
+#define PAN_MAX 4.0f
+#define PAN_MIN -4.0f
+
 class CacheEntry{//cache entries are per channel, not per user.
 public:
-    CacheEntry(QString userIp, QString userName, quint8 channelID, bool muted=false, float gain=1.0, float pan=0.0, float boost=1.0);
-    CacheEntry(){}//default constructor just to use in QMap without pointers
+    CacheEntry(const QString& userIp, const QString& userName, quint8 channelID);
+    CacheEntry(){}
 
     inline bool isMuted() const{ return muted; }
     inline float getGain() const{ return gain; }
@@ -26,13 +33,13 @@ public:
     inline QString getUserName() const{ return userName; }
     inline quint8 getChannelID() const{ return channelID; }
 
-    inline void setUserIP(QString userIp){ this->userIp = userIp; }
-    inline void setUserName(QString userName){ this->userName = userName; }
-    inline void setChannelID(quint8 channelID){ this->channelID = channelID; }
-    inline void setMuted(bool muted){ this->muted = muted; }
-    inline void setPan(float pan){ this->pan = pan; }
-    inline void setBoost(float boost) { this->boost = boost; }
-    inline void setGain(float gain){ this->gain = gain; }
+    inline void setUserIP(const QString& userIp);
+    inline void setUserName(const QString& userName);
+    inline void setChannelID(quint8 channelID);
+    inline void setMuted(bool muted);
+    inline void setPan(float pan);
+    inline void setBoost(float boost);
+    inline void setGain(float gain);
 
     static QRegExp ipPattern;
     static QRegExp namePattern;

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -14,6 +14,16 @@
 namespace Persistence {
 
 
+/**
+ * @brief The CacheEntryHeader struct
+ */
+struct CacheEntryHeader {
+    static const quint32 SIGNATURE;
+    static const quint32 REVISION;
+    static const quint32 SIZE;
+};
+
+
 class CacheEntry{//cache entries are per channel, not per user.
 public:
     CacheEntry(const QString& userIp, const QString& userName, quint8 channelID);

--- a/Client/src/persistence/UsersDataCache.h
+++ b/Client/src/persistence/UsersDataCache.h
@@ -13,12 +13,12 @@
 
 namespace Persistence {
 
-#define DEFAULT_MUTE false
-#define DEFAULT_GAIN 1.0f
-#define DEFAULT_PAN 0.0f
-#define DEFAULT_BOOST 1.0f
-#define PAN_MAX 4.0f
-#define PAN_MIN -4.0f
+constexpr int DEFAULT_MUTE = false;
+constexpr float DEFAULT_GAIN = 1.0f;
+constexpr float DEFAULT_PAN = 0.0f;
+constexpr float DEFAULT_BOOST = 1.0f;
+constexpr float PAN_MAX = 4.0f;
+constexpr float PAN_MIN = -4.0f;
 
 class CacheEntry{//cache entries are per channel, not per user.
 public:
@@ -60,7 +60,7 @@ class UsersDataCache
 public:
     UsersDataCache();
     ~UsersDataCache();
-    CacheEntry getUserCacheEntry(QString userIp, QString userName, quint8 channelID);//return default values for pan, gain and mute if user is not cached yet
+    CacheEntry getUserCacheEntry(const QString& userIp, const QString& userName, quint8 channelID);//return default values for pan, gain and mute if user is not cached yet
     void updateUserCacheEntry(CacheEntry entry);
 private:
     QMap<QString, CacheEntry> cacheEntries;

--- a/Client/tests/auto/persistence/persistence.pro
+++ b/Client/tests/auto/persistence/persistence.pro
@@ -1,0 +1,16 @@
+
+QT += testlib
+QT -= gui
+CONFIG += testcase
+TEMPLATE = app
+TARGET = persistence
+INCLUDEPATH += .
+INCLUDEPATH += ../../../src
+VPATH += ../../../src
+
+# Input
+HEADERS += log/logging.h
+HEADERS += persistence/UsersDataCache.h
+SOURCES += log/logging.cpp
+SOURCES += persistence/UsersDataCache.cpp
+SOURCES += tst_UsersDataCache.cpp

--- a/Client/tests/auto/persistence/tst_UsersDataCache.cpp
+++ b/Client/tests/auto/persistence/tst_UsersDataCache.cpp
@@ -4,6 +4,8 @@
 #include <QtTest/QtTest>
 #include "persistence/UsersDataCache.h"
 
+using namespace Persistence;
+
 class TestCacheEntry: public QObject
 {
     Q_OBJECT
@@ -18,7 +20,22 @@ private slots:
     void validUserName();
     void invalidUserName_data();
     void invalidUserName();
+
+    void defaultValues();
+
+    void setPanGuard_data();
+    void setPanGuard();
 };
+
+
+// NOTE: UsersDataCache class was not able to test without side effect
+// because destructor write to storage directly.
+class TestUsersDataCache: public QObject
+{
+    Q_OBJECT
+private slots:
+};
+
 
 void TestCacheEntry::validUserIp_data()
 {
@@ -26,47 +43,96 @@ void TestCacheEntry::validUserIp_data()
     QTest::newRow("local address") << "127.0.0.1";
     QTest::newRow("local address with mask") << "127.0.0.x";
 
-    // this is invalid as IPv4 address out of 8bit range
+    // the regex pattern will allow following unusual data.
+
+    // this is an invalid as IPv4 address, out of 8bit range
     // but we does not need to check. not making a connection.
     QTest::newRow("invalid but welformed") << "234.456.678.890";
+
+    QTest::newRow("padding") << "000.000.000.x";
 }
 
 void TestCacheEntry::validUserIp()
 {
     QFETCH(QString, addr);
-    QVERIFY(Persistence::CacheEntry::ipPattern.exactMatch(addr));
+    QVERIFY(CacheEntry::ipPattern.exactMatch(addr));
 }
 
 void TestCacheEntry::invalidUserIp_data()
 {
-    
+    QTest::addColumn<QString>("addr");
+    QTest::newRow("empty field") << "127.0..0";
+    QTest::newRow("three fields") << "127.0.0";
+    QTest::newRow("five fields") << "127.0.0.0.";
+    QTest::newRow("non digits") << "x.x.x.x";
+    QTest::newRow("negative number") << "-127.0.0.0";
 }
 
 void TestCacheEntry::invalidUserIp()
 {
-    
+    QFETCH(QString, addr);
+    QVERIFY(! CacheEntry::ipPattern.exactMatch(addr));
 }
 
 void TestCacheEntry::validUserName_data()
 {
-    
+    QTest::addColumn<QString>("name");
+    QTest::newRow("anon") << "anon";
+    QTest::newRow("underscore") << "_";
 }
 
 void TestCacheEntry::validUserName()
 {
-    
+    QFETCH(QString, name);
+    QVERIFY(CacheEntry::namePattern.exactMatch(name));
 }
 
 void TestCacheEntry::invalidUserName_data()
 {
-    
+    QTest::addColumn<QString>("name");
+    QTest::newRow("empty name") << "";
+    QTest::newRow("invalid letters") << "-";
 }
 
 void TestCacheEntry::invalidUserName()
 {
-    
+    QFETCH(QString, name);
+    QVERIFY(! CacheEntry::namePattern.exactMatch(name));
 }
 
+void TestCacheEntry::defaultValues()
+{
+    CacheEntry entry("0.0.0.x", "anon", 0);
+
+    QCOMPARE(entry.getUserIP(), QStringLiteral("0.0.0.x"));
+    QCOMPARE(entry.getUserName(), QStringLiteral("anon"));
+    QCOMPARE(entry.getChannelID(), static_cast<quint8>(0));
+    QCOMPARE(entry.isMuted(), false);
+    QCOMPARE(entry.getGain(), 1.0f);
+    QCOMPARE(entry.getPan(), 0.0f);
+    QCOMPARE(entry.getBoost(), 1.0f);
+}
+
+void TestCacheEntry::setPanGuard_data()
+{
+    QTest::addColumn<float>("actual");
+    QTest::addColumn<float>("expect");
+    QTest::newRow("default") << 0.0f << 0.0f;
+    QTest::newRow("min") << -4.0f << -4.0f;
+    QTest::newRow("max") << 4.0f << 4.0f;
+    QTest::newRow("out of min") << -4.1f << -4.0f;
+    QTest::newRow("out of max") << 4.1f << 4.0f;
+}
+
+void TestCacheEntry::setPanGuard()
+{
+    QFETCH(float, actual);
+    QFETCH(float, expect);
+    CacheEntry entry("0.0.0.x", "anon", 0);
+
+    entry.setPan(actual);
+    QCOMPARE(entry.getPan(), expect);
+}
 
 int main(int argc, char *argv[])
 {
@@ -74,6 +140,11 @@ int main(int argc, char *argv[])
 
     {
         TestCacheEntry test;
+        status |= QTest::qExec(&test, argc, argv);
+    }
+
+    {
+        TestUsersDataCache test;
         status |= QTest::qExec(&test, argc, argv);
     }
 

--- a/Client/tests/auto/persistence/tst_UsersDataCache.cpp
+++ b/Client/tests/auto/persistence/tst_UsersDataCache.cpp
@@ -6,18 +6,18 @@
 
 class TestCacheEntry: public QObject
 {
-	Q_OBJECT
+    Q_OBJECT
 
 private slots:
-	void validUserIp_data();
-	void validUserIp();
-	void invalidUserIp_data();
-	void invalidUserIp();
+    void validUserIp_data();
+    void validUserIp();
+    void invalidUserIp_data();
+    void invalidUserIp();
 
-	void validUserName_data();
-	void validUserName();
-	void invalidUserName_data();
-	void invalidUserName();
+    void validUserName_data();
+    void validUserName();
+    void invalidUserName_data();
+    void invalidUserName();
 };
 
 void TestCacheEntry::validUserIp_data()
@@ -39,43 +39,43 @@ void TestCacheEntry::validUserIp()
 
 void TestCacheEntry::invalidUserIp_data()
 {
-	
+    
 }
 
 void TestCacheEntry::invalidUserIp()
 {
-	
+    
 }
 
 void TestCacheEntry::validUserName_data()
 {
-	
+    
 }
 
 void TestCacheEntry::validUserName()
 {
-	
+    
 }
 
 void TestCacheEntry::invalidUserName_data()
 {
-	
+    
 }
 
 void TestCacheEntry::invalidUserName()
 {
-	
+    
 }
 
 
 int main(int argc, char *argv[])
 {
-	int status = 0;
+    int status = 0;
 
-	{
-		TestCacheEntry test;
-		status |= QTest::qExec(&test, argc, argv);
-	}
+    {
+        TestCacheEntry test;
+        status |= QTest::qExec(&test, argc, argv);
+    }
 
     return status;
 }

--- a/Client/tests/auto/persistence/tst_UsersDataCache.cpp
+++ b/Client/tests/auto/persistence/tst_UsersDataCache.cpp
@@ -15,11 +15,15 @@ private slots:
     void validUserIp();
     void invalidUserIp_data();
     void invalidUserIp();
+    void setUserIP_data();
+    void setUserIP();
 
     void validUserName_data();
     void validUserName();
     void invalidUserName_data();
     void invalidUserName();
+    void setUserName_data();
+    void setUserName();
 
     void defaultValues();
 
@@ -74,6 +78,24 @@ void TestCacheEntry::invalidUserIp()
     QVERIFY(! CacheEntry::ipPattern.exactMatch(addr));
 }
 
+void TestCacheEntry::setUserIP_data()
+{
+    QTest::addColumn<QString>("addr");
+    QTest::addColumn<QString>("expect");
+    QTest::newRow("ok") << "127.0.0.x" << "127.0.0.x";
+    QTest::newRow("invalid") << "xxx" << "";
+}
+
+void TestCacheEntry::setUserIP()
+{
+    QFETCH(QString, addr);
+    QFETCH(QString, expect);
+
+    CacheEntry entry(addr, "anon", 0);
+    // NOTE: constructor call setUserIp
+    QCOMPARE(entry.getUserIP(), expect);
+}
+
 void TestCacheEntry::validUserName_data()
 {
     QTest::addColumn<QString>("name");
@@ -120,8 +142,8 @@ void TestCacheEntry::setPanGuard_data()
     QTest::newRow("default") << 0.0f << 0.0f;
     QTest::newRow("min") << -4.0f << -4.0f;
     QTest::newRow("max") << 4.0f << 4.0f;
-    QTest::newRow("out of min") << -4.1f << -4.0f;
-    QTest::newRow("out of max") << 4.1f << 4.0f;
+    QTest::newRow("lower value adjust to min") << -4.1f << -4.0f;
+    QTest::newRow("upper value adjust to max") << 4.1f << 4.0f;
 }
 
 void TestCacheEntry::setPanGuard()

--- a/Client/tests/auto/persistence/tst_UsersDataCache.cpp
+++ b/Client/tests/auto/persistence/tst_UsersDataCache.cpp
@@ -1,0 +1,83 @@
+
+#include <QObject>
+#include <QString>
+#include <QtTest/QtTest>
+#include "persistence/UsersDataCache.h"
+
+class TestCacheEntry: public QObject
+{
+	Q_OBJECT
+
+private slots:
+	void validUserIp_data();
+	void validUserIp();
+	void invalidUserIp_data();
+	void invalidUserIp();
+
+	void validUserName_data();
+	void validUserName();
+	void invalidUserName_data();
+	void invalidUserName();
+};
+
+void TestCacheEntry::validUserIp_data()
+{
+    QTest::addColumn<QString>("addr");
+    QTest::newRow("local address") << "127.0.0.1";
+    QTest::newRow("local address with mask") << "127.0.0.x";
+
+    // this is invalid as IPv4 address out of 8bit range
+    // but we does not need to check. not making a connection.
+    QTest::newRow("invalid but welformed") << "234.456.678.890";
+}
+
+void TestCacheEntry::validUserIp()
+{
+    QFETCH(QString, addr);
+    QVERIFY(Persistence::CacheEntry::ipPattern.exactMatch(addr));
+}
+
+void TestCacheEntry::invalidUserIp_data()
+{
+	
+}
+
+void TestCacheEntry::invalidUserIp()
+{
+	
+}
+
+void TestCacheEntry::validUserName_data()
+{
+	
+}
+
+void TestCacheEntry::validUserName()
+{
+	
+}
+
+void TestCacheEntry::invalidUserName_data()
+{
+	
+}
+
+void TestCacheEntry::invalidUserName()
+{
+	
+}
+
+
+int main(int argc, char *argv[])
+{
+	int status = 0;
+
+	{
+		TestCacheEntry test;
+		status |= QTest::qExec(&test, argc, argv);
+	}
+
+    return status;
+}
+
+#include "tst_UsersDataCache.moc"


### PR DESCRIPTION
This is a continue from 0b608fe4417ffa50fdbe954baa46c0bb05014edc

- could be binary format?
 - if there is a chance to change the format, let discuss it first.
   QDataStream may support easy serializing QMap collection. (if its ok to read whole data)
 - [x] test QMap serialization
 - [x] versioning / signature header
- where sanitize
 - [x] CacheEntry setters
 - [x] read
 - [x] write (incoming user name from ninjam)
- format/validation
 - [x] escape format characters ";" and `endl`
 - [x] user name, research what characters are allowed
 - [x] check ip address format (maybe with mask)
 - [x] float / unsigned int 8bits / bool
- [x] error action
 - what should do if invalid data came.
   I think now is report the error, skip and use default value.
- [x] how to test (where to put test code)
  - [x] unit test
  - [x] functional test

Please comment if there were missing tasks. This is the first stage, need more details.