### PR TITLE
Fix #213 appear blank in Jamtaba's ninjam tracks

### DIFF
--- a/Client/src/Common/persistence/UsersDataCache.cpp
+++ b/Client/src/Common/persistence/UsersDataCache.cpp
@@ -22,7 +22,6 @@ const float CacheEntry::PAN_MIN = -4.0f;
 // no need to validate the number within 8 bits.
 QRegExp CacheEntry::ipPattern("(?:\\d{1,3}\\.){3}(\\d{1,3}|x)");
 
-QRegExp CacheEntry::namePattern("[a-zA-Z0-9_]{1,64}");
 
 QDataStream &operator<<(QDataStream &stream, const CacheEntry &entry)
 {
@@ -78,10 +77,7 @@ void CacheEntry::setUserIP(const QString &userIp)
 
 void CacheEntry::setUserName(const QString &userName)
 {
-    if (namePattern.exactMatch(userName))
-        this->userName = userName;
-    else
-        qCDebug(jtCache) << "invalid name: " << userName;
+    this->userName = userName;
 }
 
 void CacheEntry::setChannelID(quint8 channelID)

--- a/Client/src/Common/persistence/UsersDataCache.h
+++ b/Client/src/Common/persistence/UsersDataCache.h
@@ -72,7 +72,6 @@ public:
     void setGain(float gain);
 
     static QRegExp ipPattern;
-    static QRegExp namePattern;
 
     static const bool DEFAULT_MUTED;
     static const float DEFAULT_GAIN;

--- a/Client/tests/auto/persistence/persistence.pro
+++ b/Client/tests/auto/persistence/persistence.pro
@@ -5,8 +5,8 @@ CONFIG += testcase
 TEMPLATE = app
 TARGET = persistence
 INCLUDEPATH += .
-INCLUDEPATH += ../../../src
-VPATH += ../../../src
+INCLUDEPATH += ../../../src/Common
+VPATH += ../../../src/Common
 
 # Input
 HEADERS += log/logging.h

--- a/Client/tests/auto/persistence/tst_UsersDataCache.cpp
+++ b/Client/tests/auto/persistence/tst_UsersDataCache.cpp
@@ -18,13 +18,6 @@ private slots:
     void setUserIP_data();
     void setUserIP();
 
-    void validUserName_data();
-    void validUserName();
-    void invalidUserName_data();
-    void invalidUserName();
-    void setUserName_data();
-    void setUserName();
-
     void defaultValues();
 
     void setPanGuard_data();
@@ -94,32 +87,6 @@ void TestCacheEntry::setUserIP()
     CacheEntry entry(addr, "anon", 0);
     // NOTE: constructor call setUserIp
     QCOMPARE(entry.getUserIP(), expect);
-}
-
-void TestCacheEntry::validUserName_data()
-{
-    QTest::addColumn<QString>("name");
-    QTest::newRow("anon") << "anon";
-    QTest::newRow("underscore") << "_";
-}
-
-void TestCacheEntry::validUserName()
-{
-    QFETCH(QString, name);
-    QVERIFY(CacheEntry::namePattern.exactMatch(name));
-}
-
-void TestCacheEntry::invalidUserName_data()
-{
-    QTest::addColumn<QString>("name");
-    QTest::newRow("empty name") << "";
-    QTest::newRow("invalid letters") << "-";
-}
-
-void TestCacheEntry::invalidUserName()
-{
-    QFETCH(QString, name);
-    QVERIFY(! CacheEntry::namePattern.exactMatch(name));
 }
 
 void TestCacheEntry::defaultValues()


### PR DESCRIPTION
## Cause: CacheEntry handled "-" as invalid name

collected codes following related to issue #213

- [NinjamTrackView use CacheEntry](https://github.com/elieserdejesus/JamTaba/blob/8df37a9320b70b736939215f0eeefe104ad65b37/Client/src/Common/gui/NinjamTrackView.cpp#L158)
- [Persistence::CacheEntry::setUserName() ignore invalid name](https://github.com/elieserdejesus/JamTaba/blob/8df37a9320b70b736939215f0eeefe104ad65b37/Client/src/Common/persistence/UsersDataCache.cpp#L79)
- [I wrote test "-" as invalid letters](https://github.com/elieserdejesus/JamTaba/blob/8df37a9320b70b736939215f0eeefe104ad65b37/Client/tests/auto/persistence/tst_UsersDataCache.cpp#L116)

NOTE: I thought "-" was escaped to "_", it's ninbot 's Play list, they use "-" as delimiter.

----
## Solution: remove the `namePattern` check.

it was a white-list approach, checking if only allowed characters. it's safe and strict.
but if there were missing valid characters in the white-list, then have to add.
I am not sure what letters are valid characters.

this change will make
- ninjam room ascii only (limit some letters on the protocol)
- realtime room in future, any utf8 characters (assume limit by the protocol)

----
## side effect to sanitize

it's safe ok. the Implementation details of serialization
the name (QString) is now serialized by QDataStream

any letters can be serialized safely.
the serialize format for QString is [length of data (uint32)][data], no delimiter to escape.