### PR TITLE
[WIP] Refactoring the preferences dialog

### DIFF
--- a/Client/src/Common/MainController.cpp
+++ b/Client/src/Common/MainController.cpp
@@ -307,10 +307,9 @@ void MainController::storeWindowSettings(bool maximized, bool usingFullViewMode,
 }
 
 void MainController::storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut,
-                                     int audioDevice, int bufferSize,
-                                     const QList<bool> &midiInputsStatus)
+                                     int audioDevice, const QList<bool> &midiInputsStatus)
 {
-    settings.setAudioSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, bufferSize);
+    settings.setAudioSettings(firstIn, lastIn, firstOut, lastOut, audioDevice);
     settings.setMidiSettings(midiInputsStatus);
 }
 

--- a/Client/src/Common/MainController.cpp
+++ b/Client/src/Common/MainController.cpp
@@ -36,6 +36,7 @@ void MainController::setSampleRate(int newSampleRate)
         jamRecorder.setSampleRate(newSampleRate);
     if (isPlayingInNinjamRoom())
         ninjamController->setSampleRate(newSampleRate);
+    settings.setSampleRate(newSampleRate);
 }
 
 void MainController::finishUploads()
@@ -306,11 +307,10 @@ void MainController::storeWindowSettings(bool maximized, bool usingFullViewMode,
 }
 
 void MainController::storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut,
-                                     int audioDevice, int sampleRate, int bufferSize,
+                                     int audioDevice, int bufferSize,
                                      const QList<bool> &midiInputsStatus)
 {
-    settings.setAudioSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, sampleRate,
-                              bufferSize);
+    settings.setAudioSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, bufferSize);
     settings.setMidiSettings(midiInputsStatus);
 }
 

--- a/Client/src/Common/MainController.h
+++ b/Client/src/Common/MainController.h
@@ -169,8 +169,7 @@ public:
     void storeIntervalProgressShape(int shape);
 
     void storeWindowSettings(bool maximized, bool usingFullViewMode, QPointF location);
-    void storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice,
-                         int sampleRate, int bufferSize, const QList<bool> &midiInputStatus);
+    void storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize, const QList<bool> &midiInputStatus);
     void storeRecordingPath(const QString &newPath);
     void storeRecordingMultiTracksStatus(bool savingMultiTracks);
     inline bool isRecordingMultiTracksActivated() const

--- a/Client/src/Common/MainController.h
+++ b/Client/src/Common/MainController.h
@@ -169,7 +169,7 @@ public:
     void storeIntervalProgressShape(int shape);
 
     void storeWindowSettings(bool maximized, bool usingFullViewMode, QPointF location);
-    void storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize, const QList<bool> &midiInputStatus);
+    void storeIOSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, const QList<bool> &midiInputStatus);
     void storeRecordingPath(const QString &newPath);
     void storeRecordingMultiTracksStatus(bool savingMultiTracks);
     inline bool isRecordingMultiTracksActivated() const

--- a/Client/src/Common/audio/core/AudioDriver.cpp
+++ b/Client/src/Common/audio/core/AudioDriver.cpp
@@ -61,11 +61,9 @@ AudioDriver::~AudioDriver()
     qCDebug(jtAudio) << "AudioDriver destructor.";
 }
 
-void AudioDriver::setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                                int lastOut)
+void AudioDriver::setProperties(int firstIn, int lastIn, int firstOut, int lastOut)
 {
     stop();
-    this->audioDeviceIndex = audioDeviceIndex;
     this->globalInputRange = ChannelRange(firstIn, (lastIn - firstIn) + 1);
     this->globalOutputRange = ChannelRange(firstOut, (lastOut - firstOut) + 1);
 }

--- a/Client/src/Common/audio/core/AudioDriver.cpp
+++ b/Client/src/Common/audio/core/AudioDriver.cpp
@@ -61,18 +61,6 @@ AudioDriver::~AudioDriver()
     qCDebug(jtAudio) << "AudioDriver destructor.";
 }
 
-void AudioDriver::setProperties()
-{
-    stop();
-
-    this->bufferSize = bufferSize;
-
-    if (this->sampleRate != sampleRate) {
-        this->sampleRate = sampleRate;
-        emit sampleRateChanged(this->sampleRate);
-    }
-}
-
 void AudioDriver::setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
                                 int lastOut)
 {

--- a/Client/src/Common/audio/core/AudioDriver.cpp
+++ b/Client/src/Common/audio/core/AudioDriver.cpp
@@ -61,7 +61,7 @@ AudioDriver::~AudioDriver()
     qCDebug(jtAudio) << "AudioDriver destructor.";
 }
 
-void AudioDriver::setProperties(int bufferSize)
+void AudioDriver::setProperties()
 {
     stop();
 
@@ -74,21 +74,23 @@ void AudioDriver::setProperties(int bufferSize)
 }
 
 void AudioDriver::setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                                int lastOut, int bufferSize)
+                                int lastOut)
 {
     stop();
     this->audioDeviceIndex = audioDeviceIndex;
     this->globalInputRange = ChannelRange(firstIn, (lastIn - firstIn) + 1);
     this->globalOutputRange = ChannelRange(firstOut, (lastOut - firstOut) + 1);
-    this->bufferSize = bufferSize;
-
-    if (this->sampleRate != sampleRate) {
-        this->sampleRate = sampleRate;
-        emit sampleRateChanged(this->sampleRate);
-    }
 }
 
 void AudioDriver::setSampleRate(int newSampleRate)
 {
-    sampleRate = newSampleRate;
+    if (sampleRate != newSampleRate) {
+        sampleRate = newSampleRate;
+        emit sampleRateChanged(newSampleRate);
+    }
+}
+
+void AudioDriver::setBufferSize(int newBufferSize)
+{
+    bufferSize = newBufferSize;
 }

--- a/Client/src/Common/audio/core/AudioDriver.cpp
+++ b/Client/src/Common/audio/core/AudioDriver.cpp
@@ -61,7 +61,7 @@ AudioDriver::~AudioDriver()
     qCDebug(jtAudio) << "AudioDriver destructor.";
 }
 
-void AudioDriver::setProperties(int sampleRate, int bufferSize)
+void AudioDriver::setProperties(int bufferSize)
 {
     stop();
 
@@ -74,7 +74,7 @@ void AudioDriver::setProperties(int sampleRate, int bufferSize)
 }
 
 void AudioDriver::setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                                int lastOut, int sampleRate, int bufferSize)
+                                int lastOut, int bufferSize)
 {
     stop();
     this->audioDeviceIndex = audioDeviceIndex;
@@ -86,4 +86,9 @@ void AudioDriver::setProperties(int audioDeviceIndex, int firstIn, int lastIn, i
         this->sampleRate = sampleRate;
         emit sampleRateChanged(this->sampleRate);
     }
+}
+
+void AudioDriver::setSampleRate(int newSampleRate)
+{
+    sampleRate = newSampleRate;
 }

--- a/Client/src/Common/audio/core/AudioDriver.h
+++ b/Client/src/Common/audio/core/AudioDriver.h
@@ -60,8 +60,7 @@ signals:
 public:
     explicit AudioDriver(Controller::MainController *mainController);
     virtual ~AudioDriver();
-    virtual void setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                               int lastOut);
+    virtual void setProperties(int firstIn, int lastIn, int firstOut, int lastOut);
 
     virtual void setSampleRate(int newSampleRate);
     virtual void setBufferSize(int newBufferSize);

--- a/Client/src/Common/audio/core/AudioDriver.h
+++ b/Client/src/Common/audio/core/AudioDriver.h
@@ -62,7 +62,6 @@ public:
     virtual ~AudioDriver();
     virtual void setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
                                int lastOut);
-    virtual void setProperties();// used in mac
 
     virtual void setSampleRate(int newSampleRate);
     virtual void setBufferSize(int newBufferSize);
@@ -146,7 +145,7 @@ public:
     {
     }
 
-    inline void stop(bool ) override
+    inline void stop(bool) override
     {
     }
 

--- a/Client/src/Common/audio/core/AudioDriver.h
+++ b/Client/src/Common/audio/core/AudioDriver.h
@@ -61,10 +61,11 @@ public:
     explicit AudioDriver(Controller::MainController *mainController);
     virtual ~AudioDriver();
     virtual void setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                               int lastOut, int bufferSize);
-    virtual void setProperties(int bufferSize);// used in mac
+                               int lastOut);
+    virtual void setProperties();// used in mac
 
     virtual void setSampleRate(int newSampleRate);
+    virtual void setBufferSize(int newBufferSize);
 
     virtual void stop(bool refreshDevicesList = false) = 0;
     virtual bool start() = 0;

--- a/Client/src/Common/audio/core/AudioDriver.h
+++ b/Client/src/Common/audio/core/AudioDriver.h
@@ -61,8 +61,10 @@ public:
     explicit AudioDriver(Controller::MainController *mainController);
     virtual ~AudioDriver();
     virtual void setProperties(int audioDeviceIndex, int firstIn, int lastIn, int firstOut,
-                               int lastOut, int sampleRate, int bufferSize);
-    virtual void setProperties(int sampleRate, int bufferSize);// used in mac
+                               int lastOut, int bufferSize);
+    virtual void setProperties(int bufferSize);// used in mac
+
+    virtual void setSampleRate(int newSampleRate);
 
     virtual void stop(bool refreshDevicesList = false) = 0;
     virtual bool start() = 0;

--- a/Client/src/Common/gui/LocalTrackGroupView.cpp
+++ b/Client/src/Common/gui/LocalTrackGroupView.cpp
@@ -4,6 +4,7 @@
 #include "MainWindow.h"
 #include "log/Logging.h"
 #include <QInputDialog>
+#include "MainController.h"
 
 LocalTrackGroupView::LocalTrackGroupView(int channelIndex, MainWindow *mainFrame) :
     index(channelIndex),

--- a/Client/src/Common/gui/MainWindow.cpp
+++ b/Client/src/Common/gui/MainWindow.cpp
@@ -846,8 +846,7 @@ void MainWindow::openPreferencesDialog(QAction *action)
         stopCurrentRoomStream();
 
         PreferencesDialog *dialog = createPreferencesDialog();// factory method, overrided in derived classes MainWindowStandalone and MainWindowVST
-        Persistence::Settings settings = mainController->getSettings();
-        dialog->initialize(initialTab, settings.getRecordingSettings());// initializing here to avoid call virtual methods inside PreferencesDialog constructor
+        dialog->initialize(initialTab, mainController->getSettings());// initializing here to avoid call virtual methods inside PreferencesDialog constructor
         dialog->show();
     }
 }

--- a/Client/src/Common/gui/MainWindow.h
+++ b/Client/src/Common/gui/MainWindow.h
@@ -2,13 +2,27 @@
 #define MAIN_WINDOW_H
 
 #include "ui_MainWindow.h"
+#include <QMainWindow>
 #include "BusyDialog.h"
-#include "chords/ChordsPanel.h"
-#include "NinjamRoomWindow.h"
-#include "MainController.h"
-#include "JamRoomViewPanel.h"
+#include "persistence/Settings.h"
 #include "LocalTrackGroupView.h"
+
 // #include "performance/PerformanceMonitor.h"
+
+class PreferencesDialog;
+class LocalTrackView;
+class NinjamRoomWindow;
+class JamRoomViewPanel;
+class ChordProgression;
+class ChordsPanel;
+
+namespace Login {
+class RoomInfo;
+}
+
+namespace Controller {
+class MainController;
+}
 
 class MainWindow : public QMainWindow
 {
@@ -79,7 +93,8 @@ protected:
 
     void centerDialog(QWidget *dialog);
 
-    virtual NinjamRoomWindow *createNinjamWindow(const Login::RoomInfo &, Controller::MainController *) = 0;
+    virtual NinjamRoomWindow *createNinjamWindow(const Login::RoomInfo &,
+                                                 Controller::MainController *) = 0;
 
     virtual void setFullViewStatus(bool fullViewActivated);
 
@@ -91,9 +106,8 @@ protected:
     // this factory method is overrided in derived classes to create more specific views
     virtual LocalTrackGroupView *createLocalTrackGroupView(int channelGroupIndex);
 
-    virtual void showPreferencesDialog(int initialTab) = 0;
-
-    virtual void initializeLocalSubChannel(LocalTrackView *localTrackView, const Persistence::Subchannel &subChannel);
+    virtual void initializeLocalSubChannel(LocalTrackView *localTrackView,
+                                           const Persistence::Subchannel &subChannel);
 
     void stopCurrentRoomStream();
 
@@ -103,15 +117,18 @@ protected:
     QList<T> getLocalChannels() const
     {
         QList<T> localChannels;
-        foreach (LocalTrackGroupView * trackGroupView, localGroupChannels) {
-            localChannels.append( dynamic_cast<T>(trackGroupView));
-        }
+        foreach (LocalTrackGroupView *trackGroupView, localGroupChannels)
+            localChannels.append(dynamic_cast<T>(trackGroupView));
         return localChannels;
     }
 
     void updatePublicRoomsListLayout();
 
     bool canUseTwoColumnLayout() const;
+
+    virtual PreferencesDialog *createPreferencesDialog() = 0;
+
+    virtual void setupPreferencesDialogSignals(PreferencesDialog *dialog);
 
 protected slots:
     void closeTab(int index);
@@ -180,6 +197,10 @@ private slots:
     void refreshPublicRoomsList(const QList<Login::RoomInfo> &publicRooms);
 
     void hideChordsPanel();
+
+    //preferences dialog (these are just the common slots between Standalone and VST, the other slots are in MainWindowStandalone class)
+    void setMultiTrackRecordingStatus(bool recording);
+    void setRecordingPath(const QString &newRecordingPath);
 private:
 
     BusyDialog busyDialog;
@@ -220,7 +241,7 @@ private:
 
     ChordsPanel *createChordsPanel();
 
-    JamRoomViewPanel* createJamRoomViewPanel(const Login::RoomInfo &roomInfo);
+    JamRoomViewPanel *createJamRoomViewPanel(const Login::RoomInfo &roomInfo);
 
     void setupSignals();
     void setupWidgets();

--- a/Client/src/Common/gui/PreferencesDialog.cpp
+++ b/Client/src/Common/gui/PreferencesDialog.cpp
@@ -3,26 +3,26 @@
 
 #include <QDebug>
 #include <QFileDialog>
+#include "persistence/Settings.h"
 
 using namespace Audio;
-using namespace Controller;
 
-PreferencesDialog::PreferencesDialog(Controller::MainController *mainController,
-                                     MainWindow *mainWindow) :
+PreferencesDialog::PreferencesDialog(MainWindow *mainWindow) :
     QDialog(mainWindow),
     ui(new Ui::IODialog),
-    mainController(mainController),
     mainWindow(mainWindow)
 {
     ui->setupUi(this);
     setModal(true);
-    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint & Qt::WA_DeleteOnClose);
 
     ui->comboLastOutput->setEnabled(false);
 }
 
-void PreferencesDialog::initialize()
+void PreferencesDialog::initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings)
 {
+    Q_UNUSED(initialTab);
+    this->recordingSettings = recordingSettings;
     setupSignals();
     populateAllTabs();
 }
@@ -31,12 +31,14 @@ void PreferencesDialog::setupSignals()
 {
     // the 'accept' slot is overrided in inherited classes (StandalonePreferencesDialog and VstPreferencesDialog)
     connect(ui->okButton, SIGNAL(clicked(bool)), this, SLOT(accept()));
-    connect(ui->prefsTab, SIGNAL(currentChanged(int)), this, SLOT(selectPreferencesTab(int)));
-    connect(ui->recordingCheckBox, SIGNAL(clicked(bool)), this, SLOT(setMultiTrackRecordingStatus(bool)));
+    connect(ui->prefsTab, SIGNAL(currentChanged(int)), this, SLOT(selectTab(int)));
+    connect(ui->recordingCheckBox, SIGNAL(clicked(bool)), this,
+            SIGNAL(multiTrackRecordingStatusChanged(bool)));
     connect(ui->browseRecPathButton, SIGNAL(clicked(bool)), this, SLOT(selectRecordingPath()));
 }
 
-void PreferencesDialog::populateAllTabs(){
+void PreferencesDialog::populateAllTabs()
+{
     populateRecordingTab();
 }
 
@@ -47,10 +49,8 @@ void PreferencesDialog::selectRecordingTab()
 
 void PreferencesDialog::populateRecordingTab()
 {
-    QString recordingPath = mainController->getSettings().getRecordingPath();
-    QDir recordDir(recordingPath);
-    bool isSaveMultiTrackActivated = mainController->getSettings().isSaveMultiTrackActivated();
-    ui->recordingCheckBox->setChecked(isSaveMultiTrackActivated);
+    QDir recordDir(recordingSettings.recordingPath);
+    ui->recordingCheckBox->setChecked(recordingSettings.saveMultiTracksActivated);
     ui->recordPathLineEdit->setText(recordDir.absolutePath());
 }
 
@@ -59,7 +59,6 @@ PreferencesDialog::~PreferencesDialog()
     delete ui;
 }
 
-// Recording TAB controls --------------------
 void PreferencesDialog::selectRecordingPath()
 {
     QFileDialog fileDialog(this, "Choosing recording path ...");
@@ -67,12 +66,8 @@ void PreferencesDialog::selectRecordingPath()
     fileDialog.setFileMode(QFileDialog::DirectoryOnly);
     if (fileDialog.exec()) {
         QDir dir = fileDialog.directory();
-        mainController->storeRecordingPath(dir.absolutePath());
-        ui->recordPathLineEdit->setText(dir.absolutePath());
+        QString newRecordingPath = dir.absolutePath();
+        ui->recordPathLineEdit->setText(newRecordingPath);
+        emit recordingPathSelected(newRecordingPath);
     }
-}
-
-void PreferencesDialog::setMultiTrackRecordingStatus(bool recordingActivated)
-{
-    mainController->storeRecordingMultiTracksStatus(recordingActivated);
 }

--- a/Client/src/Common/gui/PreferencesDialog.cpp
+++ b/Client/src/Common/gui/PreferencesDialog.cpp
@@ -16,10 +16,10 @@ PreferencesDialog::PreferencesDialog(QWidget *parent) :
     ui->comboLastOutput->setEnabled(false);
 }
 
-void PreferencesDialog::initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings)
+void PreferencesDialog::initialize(int initialTab, const Persistence::Settings &settings)
 {
     Q_UNUSED(initialTab);
-    this->recordingSettings = recordingSettings;
+    this->settings = settings;
     setupSignals();
     populateAllTabs();
 }
@@ -46,6 +46,7 @@ void PreferencesDialog::selectRecordingTab()
 
 void PreferencesDialog::populateRecordingTab()
 {
+    Persistence::RecordingSettings recordingSettings = settings.getRecordingSettings();
     QDir recordDir(recordingSettings.recordingPath);
     ui->recordingCheckBox->setChecked(recordingSettings.saveMultiTracksActivated);
     ui->recordPathLineEdit->setText(recordDir.absolutePath());

--- a/Client/src/Common/gui/PreferencesDialog.cpp
+++ b/Client/src/Common/gui/PreferencesDialog.cpp
@@ -5,12 +5,9 @@
 #include <QFileDialog>
 #include "persistence/Settings.h"
 
-using namespace Audio;
-
-PreferencesDialog::PreferencesDialog(MainWindow *mainWindow) :
-    QDialog(mainWindow),
-    ui(new Ui::IODialog),
-    mainWindow(mainWindow)
+PreferencesDialog::PreferencesDialog(QWidget *parent) :
+    QDialog(parent),
+    ui(new Ui::IODialog)
 {
     ui->setupUi(this);
     setModal(true);

--- a/Client/src/Common/gui/PreferencesDialog.h
+++ b/Client/src/Common/gui/PreferencesDialog.h
@@ -2,7 +2,7 @@
 #define PREFERENCES_DIALOG_H
 
 #include <QDialog>
-#include "MainWindow.h"
+#include "persistence/Settings.h"
 
 namespace Ui {
 class IODialog;
@@ -14,7 +14,7 @@ class PreferencesDialog : public QDialog
 {
     Q_OBJECT
 public:
-    PreferencesDialog(MainWindow *mainWindow);
+    PreferencesDialog(QWidget *parent);
     virtual ~PreferencesDialog();
 
     virtual void initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings);
@@ -35,7 +35,6 @@ private slots:
 
 protected:
     Ui::IODialog *ui;
-    MainWindow *mainWindow;
 
     // recording
     void populateRecordingTab();

--- a/Client/src/Common/gui/PreferencesDialog.h
+++ b/Client/src/Common/gui/PreferencesDialog.h
@@ -17,7 +17,7 @@ public:
     PreferencesDialog(QWidget *parent);
     virtual ~PreferencesDialog();
 
-    virtual void initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings);
+    virtual void initialize(int initialTab, const Persistence::Settings &settings);
 
     enum TAB {
         TAB_AUDIO, TAB_MIDI, TAB_VST, TAB_RECORDING
@@ -43,7 +43,7 @@ protected:
     virtual void setupSignals();
     virtual void populateAllTabs();
 
-    Persistence::RecordingSettings recordingSettings;
+    Persistence::Settings settings;
 
 };
 

--- a/Client/src/Common/gui/PreferencesDialog.h
+++ b/Client/src/Common/gui/PreferencesDialog.h
@@ -3,7 +3,6 @@
 
 #include <QDialog>
 #include "MainWindow.h"
-#include "MainController.h"
 
 namespace Ui {
 class IODialog;
@@ -15,25 +14,27 @@ class PreferencesDialog : public QDialog
 {
     Q_OBJECT
 public:
-    PreferencesDialog(Controller::MainController *mainController, MainWindow *mainWindow);
+    PreferencesDialog(MainWindow *mainWindow);
     virtual ~PreferencesDialog();
 
-    void initialize();
+    virtual void initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings);
 
     enum TAB {
         TAB_AUDIO, TAB_MIDI, TAB_VST, TAB_RECORDING
     };
 
+signals:
+    void recordingPathSelected(const QString &newRecordingPath);
+    void multiTrackRecordingStatusChanged(bool recording);
+
 protected slots:
-    virtual void selectPreferencesTab(int index) = 0;
+    virtual void selectTab(int index) = 0;
 
 private slots:
     void selectRecordingPath();
-    void setMultiTrackRecordingStatus(bool recordingActivated);
 
 protected:
     Ui::IODialog *ui;
-    Controller::MainController *mainController;
     MainWindow *mainWindow;
 
     // recording
@@ -42,6 +43,9 @@ protected:
 
     virtual void setupSignals();
     virtual void populateAllTabs();
+
+    Persistence::RecordingSettings recordingSettings;
+
 };
 
 #endif

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="prefsTab">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabAudio">
       <attribute name="title">
@@ -429,8 +429,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>98</width>
-               <height>28</height>
+               <width>378</width>
+               <height>65</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_10">

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="prefsTab">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabAudio">
       <attribute name="title">

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -344,6 +344,16 @@
           <item>
            <layout class="QHBoxLayout" name="buttonsLayout">
             <item>
+             <widget class="QPushButton" name="buttonVstRefresh">
+              <property name="toolTip">
+               <string>Scan only new plugins</string>
+              </property>
+              <property name="text">
+               <string>Refresh</string>
+              </property>
+             </widget>
+            </item>
+            <item>
              <widget class="QPushButton" name="buttonClearVstAndScan">
               <property name="toolTip">
                <string>Clear plugins cache and scan all plugin folders</string>
@@ -364,16 +374,6 @@
              <widget class="QPushButton" name="buttonRemoveVstFromBlackList">
               <property name="text">
                <string>Remove from blackList</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="buttonVstRefresh">
-              <property name="toolTip">
-               <string>Scan only new plugins</string>
-              </property>
-              <property name="text">
-               <string>Refresh</string>
               </property>
              </widget>
             </item>

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>480</width>
-    <height>513</height>
+    <height>507</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,201 +23,240 @@
       <attribute name="title">
        <string>Audio</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,1,1,1">
+       <property name="spacing">
+        <number>20</number>
+       </property>
        <item>
-        <widget class="QWidget" name="widget" native="true">
-         <layout class="QVBoxLayout" name="verticalLayout_3">
+        <widget class="QGroupBox" name="audioDeviceGroupBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Audio Device</string>
+         </property>
+         <layout class="QHBoxLayout" name="deviceLayout" stretch="0">
           <property name="spacing">
-           <number>20</number>
+           <number>6</number>
           </property>
-          <item>
-           <layout class="QHBoxLayout" name="deviceLayout" stretch="0,0">
-            <property name="spacing">
-             <number>6</number>
+          <item alignment="Qt::AlignVCenter">
+           <widget class="QComboBox" name="comboAudioDevice">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <property name="sizeConstraint">
-             <enum>QLayout::SetDefaultConstraint</enum>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
-            <item>
-             <widget class="QLabel" name="asioDriverLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="text">
-               <string>Device</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="comboAudioDevice">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="sizeIncrement">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <widget class="QGroupBox" name="groupBoxInputs">
-            <property name="title">
-             <string>Inputs</string>
+            <property name="sizeIncrement">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
             </property>
-            <property name="flat">
-             <bool>false</bool>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_4">
-             <item>
-              <layout class="QFormLayout" name="formLayout_4">
-               <item row="0" column="0">
-                <widget class="QLabel" name="firstInputLabel_2">
-                 <property name="text">
-                  <string>First</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QComboBox" name="comboFirstInput"/>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="lastInputLabel_2">
-                 <property name="text">
-                  <string>Last</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QComboBox" name="comboLastInput"/>
-               </item>
-              </layout>
-             </item>
-            </layout>
            </widget>
           </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxInputs">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Inputs</string>
+         </property>
+         <property name="flat">
+          <bool>false</bool>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_4">
           <item>
-           <widget class="QGroupBox" name="groupBoxOutputs">
-            <property name="title">
-             <string>Outpus</string>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <layout class="QFormLayout" name="formLayout_3">
-               <item row="0" column="0">
-                <widget class="QLabel" name="firstOutputLabel_2">
-                 <property name="text">
-                  <string>First</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QComboBox" name="comboFirstOutput"/>
-               </item>
-               <item row="1" column="0">
-                <widget class="QLabel" name="lastOutputLabel_2">
-                 <property name="text">
-                  <string>Last</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QComboBox" name="comboLastOutput"/>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="sampleRateBfferSizeLayout">
-            <property name="spacing">
-             <number>3</number>
-            </property>
-            <item>
-             <widget class="QLabel" name="sampleRateLabel">
+           <layout class="QFormLayout" name="formLayout_4">
+            <item row="0" column="0">
+             <widget class="QLabel" name="firstInputLabel_2">
               <property name="text">
-               <string>Sample rate</string>
+               <string>First</string>
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QComboBox" name="comboSampleRate"/>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="comboFirstInput"/>
             </item>
-            <item>
-             <spacer name="sampleRateBufferSizeSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="bufferSizeLabel">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lastInputLabel_2">
               <property name="text">
-               <string>Buffer size</string>
+               <string>Last</string>
               </property>
              </widget>
             </item>
-            <item>
-             <widget class="QComboBox" name="comboBufferSize"/>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>30</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="buttonControlPanel">
-              <property name="text">
-               <string>ASIO panel ...</string>
-              </property>
-             </widget>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="comboLastInput"/>
             </item>
            </layout>
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBoxOutputs">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="title">
+          <string>Outpus</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <layout class="QFormLayout" name="formLayout_3">
+            <item row="0" column="0">
+             <widget class="QLabel" name="firstOutputLabel_2">
+              <property name="text">
+               <string>First</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="comboFirstOutput"/>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="lastOutputLabel_2">
+              <property name="text">
+               <string>Last</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QComboBox" name="comboLastOutput"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="sampleRateBfferSizeLayout">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="sampleRateLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Sample rate</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboSampleRate">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="sampleRateBufferSizeSpacer">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Expanding</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QLabel" name="bufferSizeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Buffer size</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBufferSize">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>30</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="buttonControlPanel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>ASIO panel ...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
       </layout>
      </widget>
@@ -276,10 +315,13 @@
       </layout>
      </widget>
      <widget class="QWidget" name="tabVST">
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
       <attribute name="title">
        <string>VST</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
+      <layout class="QGridLayout" name="gridLayout_3" rowstretch="0,0">
        <item row="1" column="0">
         <widget class="QGroupBox" name="groupBoxVst">
          <property name="title">
@@ -300,56 +342,42 @@
            </widget>
           </item>
           <item>
-           <widget class="QWidget" name="widget_2" native="true">
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="buttonVstRefresh">
-               <property name="toolTip">
-                <string>Scan only new plugins</string>
-               </property>
-               <property name="text">
-                <string>Refresh</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="buttonClearVstAndScan">
-               <property name="toolTip">
-                <string>Clear plugins cache and scan all plugin folders</string>
-               </property>
-               <property name="text">
-                <string>Clear and Scan</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="buttonAddVstToBlackList">
-               <property name="text">
-                <string>Add to black List</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="buttonRemoveVstFromBlackList">
-               <property name="text">
-                <string>Remove from blackList</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonsLayout">
+            <item>
+             <widget class="QPushButton" name="buttonClearVstAndScan">
+              <property name="toolTip">
+               <string>Clear plugins cache and scan all plugin folders</string>
+              </property>
+              <property name="text">
+               <string>Clear and Scan</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonAddVstToBlackList">
+              <property name="text">
+               <string>Add to black List</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonRemoveVstFromBlackList">
+              <property name="text">
+               <string>Remove from blackList</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonVstRefresh">
+              <property name="toolTip">
+               <string>Scan only new plugins</string>
+              </property>
+              <property name="text">
+               <string>Refresh</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPlainTextEdit" name="blackListWidget">
@@ -373,29 +401,26 @@
        <item row="0" column="0">
         <widget class="QGroupBox" name="groupBoxPaths">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>100</height>
-          </size>
-         </property>
          <property name="maximumSize">
           <size>
            <width>16777215</width>
-           <height>100</height>
+           <height>120</height>
           </size>
+         </property>
+         <property name="styleSheet">
+          <string notr="true"/>
          </property>
          <property name="title">
           <string>Plugin Paths:</string>
          </property>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <property name="spacing">
-           <number>6</number>
+           <number>9</number>
           </property>
           <property name="leftMargin">
            <number>9</number>
@@ -407,10 +432,16 @@
            <number>9</number>
           </property>
           <property name="bottomMargin">
-           <number>9</number>
+           <number>3</number>
           </property>
-          <item>
+          <item alignment="Qt::AlignTop">
            <widget class="QPushButton" name="buttonAddVstScanFolder">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="MinimumExpanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="toolTip">
              <string>Add a new folder to scan ...</string>
             </property>
@@ -419,8 +450,20 @@
             </property>
            </widget>
           </item>
-          <item>
+          <item alignment="Qt::AlignTop">
            <widget class="QScrollArea" name="scrollArea">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>50</height>
+             </size>
+            </property>
             <property name="widgetResizable">
              <bool>true</bool>
             </property>
@@ -429,13 +472,25 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>378</width>
-               <height>65</height>
+               <width>375</width>
+               <height>45</height>
               </rect>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>45</height>
+              </size>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_10">
               <property name="spacing">
-               <number>3</number>
+               <number>0</number>
               </property>
               <property name="leftMargin">
                <number>6</number>
@@ -512,60 +567,46 @@
     </widget>
    </item>
    <item>
-    <widget class="QWidget" name="widgetBottom" native="true">
-     <layout class="QHBoxLayout" name="horizontalLayout_4">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>280</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="okButton">
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="autoFillBackground">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>ok</string>
-        </property>
-        <property name="default">
-         <bool>false</bool>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
+    <layout class="QHBoxLayout" name="bottomLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>280</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="okButton">
+       <property name="maximumSize">
+        <size>
+         <width>100</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="autoFillBackground">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>ok</string>
+       </property>
+       <property name="default">
+        <bool>false</bool>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="prefsTab">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="tabAudio">
       <attribute name="title">
@@ -315,7 +315,7 @@
               <number>0</number>
              </property>
              <item>
-              <widget class="QPushButton" name="ButtonVst_Refresh">
+              <widget class="QPushButton" name="buttonVstRefresh">
                <property name="toolTip">
                 <string>Scan only new plugins</string>
                </property>
@@ -335,14 +335,14 @@
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="ButtonVST_AddToBlackList">
+              <widget class="QPushButton" name="buttonAddVstToBlackList">
                <property name="text">
                 <string>Add to black List</string>
                </property>
               </widget>
              </item>
              <item>
-              <widget class="QPushButton" name="ButtonVST_RemFromBlkList">
+              <widget class="QPushButton" name="buttonRemoveVstFromBlackList">
                <property name="text">
                 <string>Remove from blackList</string>
                </property>

--- a/Client/src/Common/gui/PreferencesDialog.ui
+++ b/Client/src/Common/gui/PreferencesDialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTabWidget" name="prefsTab">
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="tabAudio">
       <attribute name="title">
@@ -429,8 +429,8 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>378</width>
-               <height>65</height>
+               <width>98</width>
+               <height>28</height>
               </rect>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout_10">

--- a/Client/src/Common/persistence/Settings.cpp
+++ b/Client/src/Common/persistence/Settings.cpp
@@ -509,16 +509,20 @@ void Settings::setWindowSettings(bool windowIsMaximized, bool usingFullView, QPo
 }
 
 // ++++++++++++++++++++++++++++++++++++++++
-void Settings::setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice,
-                                int sampleRate, int bufferSize)
+void Settings::setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize)
 {
     audioSettings.bufferSize = bufferSize;
-    audioSettings.sampleRate = sampleRate;
+    //audioSettings.sampleRate = sampleRate;
     audioSettings.firstIn = firstIn;
     audioSettings.firstOut = firstOut;
     audioSettings.lastIn = lastIn;
     audioSettings.lastOut = lastOut;
     audioSettings.audioDevice = audioDevice;
+}
+
+void Settings::setSampleRate(int newSampleRate)
+{
+    audioSettings.sampleRate = newSampleRate;
 }
 
 // io ops ...

--- a/Client/src/Common/persistence/Settings.cpp
+++ b/Client/src/Common/persistence/Settings.cpp
@@ -509,10 +509,8 @@ void Settings::setWindowSettings(bool windowIsMaximized, bool usingFullView, QPo
 }
 
 // ++++++++++++++++++++++++++++++++++++++++
-void Settings::setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize)
+void Settings::setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice)
 {
-    audioSettings.bufferSize = bufferSize;
-    //audioSettings.sampleRate = sampleRate;
     audioSettings.firstIn = firstIn;
     audioSettings.firstOut = firstOut;
     audioSettings.lastIn = lastIn;
@@ -523,6 +521,11 @@ void Settings::setAudioSettings(int firstIn, int lastIn, int firstOut, int lastO
 void Settings::setSampleRate(int newSampleRate)
 {
     audioSettings.sampleRate = newSampleRate;
+}
+
+void Settings::setBufferSize(int bufferSize)
+{
+    audioSettings.bufferSize = bufferSize;
 }
 
 // io ops ...

--- a/Client/src/Common/persistence/Settings.cpp
+++ b/Client/src/Common/persistence/Settings.cpp
@@ -436,9 +436,9 @@ void Settings::addVstToBlackList(const QString &pluginPath)
         vstSettings.blackedPlugins.append(pluginPath);
 }
 
-void Settings::RemVstFromBlackList(int index)
+void Settings::removeVstFromBlackList(const QString &pluginPath)
 {
-    vstSettings.blackedPlugins.removeAt(index);
+    vstSettings.blackedPlugins.removeOne(pluginPath);
 }
 
 QStringList Settings::getVstPluginsPaths() const

--- a/Client/src/Common/persistence/Settings.h
+++ b/Client/src/Common/persistence/Settings.h
@@ -297,6 +297,11 @@ public:
         return recordingSettings.saveMultiTracksActivated;
     }
 
+    inline RecordingSettings getRecordingSettings() const
+    {
+        return recordingSettings;
+    }
+
     inline QString getRecordingPath() const
     {
         return recordingSettings.recordingPath;

--- a/Client/src/Common/persistence/Settings.h
+++ b/Client/src/Common/persistence/Settings.h
@@ -340,7 +340,7 @@ public:
     // VST
     void addVstPlugin(const QString &pluginPath);
     void addVstToBlackList(const QString &pluginPath);
-    void RemVstFromBlackList(int index);
+    void removeVstFromBlackList(const QString &pluginPath);
     QStringList getVstPluginsPaths() const;
     QStringList getBlackListedPlugins() const;
     void clearVstCache();

--- a/Client/src/Common/persistence/Settings.h
+++ b/Client/src/Common/persistence/Settings.h
@@ -392,9 +392,10 @@ public:
 
     void setFullScreenView(bool v);
     // ++++++++++++++++++++++++++++++++++++++++
-    void setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize);
+    void setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice);
 
     void setSampleRate(int newSampleRate);
+    void setBufferSize(int bufferSize);
 
     inline int getFirstGlobalAudioInput() const
     {

--- a/Client/src/Common/persistence/Settings.h
+++ b/Client/src/Common/persistence/Settings.h
@@ -392,8 +392,9 @@ public:
 
     void setFullScreenView(bool v);
     // ++++++++++++++++++++++++++++++++++++++++
-    void setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice,
-                          int sampleRate, int bufferSize);
+    void setAudioSettings(int firstIn, int lastIn, int firstOut, int lastOut, int audioDevice, int bufferSize);
+
+    void setSampleRate(int newSampleRate);
 
     inline int getFirstGlobalAudioInput() const
     {

--- a/Client/src/Standalone/MainControllerStandalone.cpp
+++ b/Client/src/Standalone/MainControllerStandalone.cpp
@@ -117,9 +117,9 @@ void MainControllerStandalone::addBlackVstToSettings(const QString &path)
     settings.addVstToBlackList(path);
 }
 
-void MainControllerStandalone::removeBlackVst(int index)
+void MainControllerStandalone::removeBlackVstFromSettings(const QString &pluginPath)
 {
-    settings.RemVstFromBlackList(index);
+    settings.removeVstFromBlackList(pluginPath);
 }
 
 bool MainControllerStandalone::inputIndexIsValid(int inputIndex)

--- a/Client/src/Standalone/MainControllerStandalone.cpp
+++ b/Client/src/Standalone/MainControllerStandalone.cpp
@@ -512,6 +512,13 @@ void MainControllerStandalone::scanPlugins(bool scanOnlyNewPlugins)
     }
 }
 
+void MainControllerStandalone::openExternalAudioControlPanel()
+{
+    if (audioDriver->hasControlPanel())// just in case
+        audioDriver->openControlPanel((void *)mainWindow->winId());
+}
+
+
 void MainControllerStandalone::stopNinjamController()
 {
     MainController::stopNinjamController();

--- a/Client/src/Standalone/MainControllerStandalone.cpp
+++ b/Client/src/Standalone/MainControllerStandalone.cpp
@@ -482,6 +482,19 @@ void MainControllerStandalone::initializePluginsList(const QStringList &paths)
     }
 }
 
+void MainControllerStandalone::scanAllPlugins()
+{
+    saveLastUserSettings(settings.getInputsSettings());// save the config file before start scanning
+    clearPluginsCache();
+    scanPlugins(false);
+}
+
+void MainControllerStandalone::scanOnlyNewPlugins()
+{
+    saveLastUserSettings(settings.getInputsSettings());// save the config file before start scanning
+    scanPlugins(true);
+}
+
 void MainControllerStandalone::scanPlugins(bool scanOnlyNewPlugins)
 {
     if (pluginFinder) {

--- a/Client/src/Standalone/MainControllerStandalone.cpp
+++ b/Client/src/Standalone/MainControllerStandalone.cpp
@@ -202,12 +202,14 @@ void MainControllerStandalone::setSampleRate(int newSampleRate)
         inputNode->setProcessorsSampleRate(newSampleRate);
 }
 
+void MainControllerStandalone::setBufferSize(int newBufferSize)
+{
+    vstHost->setBlockSize(newBufferSize);
+    settings.setBufferSize(newBufferSize);
+}
+
 void MainControllerStandalone::on_audioDriverStarted()
 {
-
-    vstHost->setSampleRate(audioDriver->getSampleRate());
-    vstHost->setBlockSize(audioDriver->getBufferSize());
-
     foreach (Audio::LocalInputAudioNode *inputTrack, inputTracks)
         inputTrack->resumeProcessors();
 }

--- a/Client/src/Standalone/MainControllerStandalone.h
+++ b/Client/src/Standalone/MainControllerStandalone.h
@@ -35,10 +35,8 @@ public:
     void initializePluginsList(const QStringList &paths);
     void scanPlugins(bool scanOnlyNewPlugins = false);
 
-    void addBlackVstToSettings(const QString &path);
     void addDefaultPluginsScanPath();// add vst path from registry
 
-    void removeBlackVst(int index);
     void clearPluginsCache();
     QStringList getSteinbergRecommendedPaths();
     bool pluginsScanIsNeeded() const; // plugins cache is empty OR we have new plugins in scan folders?
@@ -102,6 +100,9 @@ public slots:
 
     void removePluginsScanPath(const QString &path);
     void addPluginsScanPath(const QString &path);
+
+    void addBlackVstToSettings(const QString &path);
+    void removeBlackVstFromSettings(const QString &pluginPath);
 
 protected:
     Midi::MidiDriver *createMidiDriver();

--- a/Client/src/Standalone/MainControllerStandalone.h
+++ b/Client/src/Standalone/MainControllerStandalone.h
@@ -98,6 +98,7 @@ public:
 
 public slots:
     void setSampleRate(int newSampleRate) override;
+    void setBufferSize(int newBufferSize);
 
 protected:
     Midi::MidiDriver *createMidiDriver();

--- a/Client/src/Standalone/MainControllerStandalone.h
+++ b/Client/src/Standalone/MainControllerStandalone.h
@@ -106,6 +106,8 @@ public slots:
     void scanAllPlugins();
     void scanOnlyNewPlugins();
 
+    void openExternalAudioControlPanel();
+
 protected:
     Midi::MidiDriver *createMidiDriver();
 

--- a/Client/src/Standalone/MainControllerStandalone.h
+++ b/Client/src/Standalone/MainControllerStandalone.h
@@ -34,10 +34,10 @@ public:
 
     void initializePluginsList(const QStringList &paths);
     void scanPlugins(bool scanOnlyNewPlugins = false);
-    void addPluginsScanPath(const QString &path);
+
     void addBlackVstToSettings(const QString &path);
     void addDefaultPluginsScanPath();// add vst path from registry
-    void removePluginsScanPath(const QString &path);
+
     void removeBlackVst(int index);
     void clearPluginsCache();
     QStringList getSteinbergRecommendedPaths();
@@ -99,6 +99,9 @@ public:
 public slots:
     void setSampleRate(int newSampleRate) override;
     void setBufferSize(int newBufferSize);
+
+    void removePluginsScanPath(const QString &path);
+    void addPluginsScanPath(const QString &path);
 
 protected:
     Midi::MidiDriver *createMidiDriver();

--- a/Client/src/Standalone/MainControllerStandalone.h
+++ b/Client/src/Standalone/MainControllerStandalone.h
@@ -33,7 +33,6 @@ public:
     ~MainControllerStandalone();
 
     void initializePluginsList(const QStringList &paths);
-    void scanPlugins(bool scanOnlyNewPlugins = false);
 
     void addDefaultPluginsScanPath();// add vst path from registry
 
@@ -104,6 +103,9 @@ public slots:
     void addBlackVstToSettings(const QString &path);
     void removeBlackVstFromSettings(const QString &pluginPath);
 
+    void scanAllPlugins();
+    void scanOnlyNewPlugins();
+
 protected:
     Midi::MidiDriver *createMidiDriver();
 
@@ -158,6 +160,8 @@ private:
                                          const Audio::PluginDescriptor &d2);
 
     Audio::Plugin *createPluginInstance(const Audio::PluginDescriptor &descriptor);
+
+    void scanPlugins(bool scanOnlyNewPlugins);
 
 };
 }

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -317,6 +317,9 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     connect(dialog, SIGNAL(vstScanDirRemoved(const QString &)), controller, SLOT(removePluginsScanPath(const QString &)));
     connect(dialog, SIGNAL(vstScanDirAdded(const QString &)), controller, SLOT(addPluginsScanPath(const QString &)));
 
+    connect(dialog, SIGNAL(vstPluginAddedInBlackList(const QString &)), controller, SLOT(addBlackVstToSettings(const QString &)));
+    connect(dialog, SIGNAL(vstPluginRemovedFromBlackList(const QString &)), controller, SLOT(removeBlackVstFromSettings(const QString &)));
+
     return dialog;
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -309,7 +309,14 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
 
     connect(dialog, SIGNAL(rejected()), this, SLOT(restartAudioAndMidi()));
 
+    connect(dialog, SIGNAL(sampleRateChanged(int)), this, SLOT(setSampleRate(int)));
+
     return dialog;
+}
+
+void MainWindowStandalone::setSampleRate(int newSampleRate)
+{
+    controller->setSampleRate(newSampleRate);
 }
 
 void MainWindowStandalone::restartAudioAndMidi()
@@ -350,20 +357,18 @@ void MainWindowStandalone::handleServerConnectionError(const QString &msg)
 
 void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsStatus,
                                                 int audioDevice, int firstIn, int lastIn,
-                                                int firstOut, int lastOut, int sampleRate,
+                                                int firstOut, int lastOut,
                                                 int bufferSize)
 {
     Audio::AudioDriver *audioDriver = controller->getAudioDriver();
 
 #ifdef Q_OS_WIN
-    audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut, sampleRate,
-                               bufferSize);
+    audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut, bufferSize);
 #endif
 #ifdef Q_OS_MACX
-    audioDriver->setProperties(sampleRate, bufferSize);
+    audioDriver->setProperties(bufferSize);
 #endif
-    controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, sampleRate,
-                                bufferSize, midiInputsStatus);
+    controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, bufferSize, midiInputsStatus);
 
     Midi::MidiDriver *midiDriver = controller->getMidiDriver();
     midiDriver->setInputDevicesStatus(midiInputsStatus);

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -314,6 +314,9 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
 
     connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), dialog, SLOT(populateVstTab()));
 
+    connect(dialog, SIGNAL(vstScanDirRemoved(const QString &)), controller, SLOT(removePluginsScanPath(const QString &)));
+    connect(dialog, SIGNAL(vstScanDirAdded(const QString &)), controller, SLOT(addPluginsScanPath(const QString &)));
+
     return dialog;
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -276,33 +276,39 @@ void MainWindowStandalone::closeEvent(QCloseEvent *e)
 }
 
 //+++++++++++++++++++=+
-void MainWindowStandalone::showPreferencesDialog(int initialTab)
+//void MainWindowStandalone::showPreferencesDialog(int initialTab)
+//{
+
+//    Midi::MidiDriver *midiDriver = controller->getMidiDriver();
+//    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
+//    if (audioDriver)
+//        audioDriver->stop(true);//asking audio driver to refresh the devices list
+//    if (midiDriver)
+//        midiDriver->stop();
+
+//    StandalonePreferencesDialog dialog(controller, this);
+//    dialog.initialize(initialTab);
+
+//    connect(&dialog,
+//            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int, int, int)),
+//            this,
+//            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int, int, int)));
+
+//    int result = dialog.exec();
+//    if (result == QDialog::Rejected) {
+//        if (midiDriver)
+//            midiDriver->start(controller->getSettings().getMidiInputDevicesStatus());// restart audio and midi drivers if user cancel the preferences menu
+//        if (audioDriver)
+//            audioDriver->start();
+//    }
+//    /** audio driver parameters are changed in on_IOPropertiesChanged. This slot is always invoked when AudioIODialog is closed.*/
+//}
+
+PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
 {
-    stopCurrentRoomStream();
-
-    Midi::MidiDriver *midiDriver = controller->getMidiDriver();
-    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
-    if (audioDriver)
-        audioDriver->stop(true);//asking audio driver to refresh the devices list
-    if (midiDriver)
-        midiDriver->stop();
-
-    StandalonePreferencesDialog dialog(controller, this);
-    dialog.initialize(initialTab);
-
-    connect(&dialog,
-            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int, int, int)),
-            this,
-            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int, int, int)));
-
-    int result = dialog.exec();
-    if (result == QDialog::Rejected) {
-        if (midiDriver)
-            midiDriver->start(controller->getSettings().getMidiInputDevicesStatus());// restart audio and midi drivers if user cancel the preferences menu
-        if (audioDriver)
-            audioDriver->start();
-    }
-    /** audio driver parameters are changed in on_IOPropertiesChanged. This slot is always invoked when AudioIODialog is closed.*/
+    PreferencesDialog * dialog = new StandalonePreferencesDialog(controller, this);
+    setupPreferencesDialogSignals(dialog);
+    return dialog;
 }
 
 // ++++++++++++++++++++++

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -313,12 +313,16 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     connect(dialog, SIGNAL(bufferSizeChanged(int)), controller, SLOT(setBufferSize(int)));
 
     connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), dialog, SLOT(populateVstTab()));
+    connect(controller->getPluginFinder(), SIGNAL(scanStarted()), dialog, SLOT(clearVstList()));
 
     connect(dialog, SIGNAL(vstScanDirRemoved(const QString &)), controller, SLOT(removePluginsScanPath(const QString &)));
     connect(dialog, SIGNAL(vstScanDirAdded(const QString &)), controller, SLOT(addPluginsScanPath(const QString &)));
 
     connect(dialog, SIGNAL(vstPluginAddedInBlackList(const QString &)), controller, SLOT(addBlackVstToSettings(const QString &)));
     connect(dialog, SIGNAL(vstPluginRemovedFromBlackList(const QString &)), controller, SLOT(removeBlackVstFromSettings(const QString &)));
+
+    connect(dialog, SIGNAL(startingFullPluginsScan()), controller, SLOT(scanAllPlugins()));
+    connect(dialog, SIGNAL(startingOnlyNewPluginsScan()), controller, SLOT(scanOnlyNewPlugins()));
 
     return dialog;
 }
@@ -348,8 +352,7 @@ void MainWindowStandalone::initializePluginFinder()
     if (controller->pluginsScanIsNeeded()) {// no vsts in database cache or new plugins detected in scan folders?
         if (settings.getVstScanFolders().isEmpty())
             controller->addDefaultPluginsScanPath();
-        controller->saveLastUserSettings(getInputsSettings());// save config file before scan
-        controller->scanPlugins(true);
+        controller->scanOnlyNewPlugins();
     }
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -297,35 +297,44 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     midiDriver->stop();
 
     bool showAudioControlPanelButton = controller->getAudioDriver()->hasControlPanel();
-    StandalonePreferencesDialog *dialog = new StandalonePreferencesDialog(controller, this, showAudioControlPanelButton);
+    StandalonePreferencesDialog *dialog = new StandalonePreferencesDialog(this,
+                                                                          showAudioControlPanelButton,
+                                                                          controller->getAudioDriver(),
+                                                                          controller->getMidiDriver());
 
     // setup signals related with recording
     MainWindow::setupPreferencesDialogSignals(dialog);
 
     // setup standalone specific signals
     connect(dialog,
-            SIGNAL(ioPreferencesChanged(QList<bool>,int,int,int,int,int)),
+            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int)),
             this,
-            SLOT(setGlobalPreferences(QList<bool>,int,int,int,int,int)));
+            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int)));
 
     connect(dialog, SIGNAL(rejected()), this, SLOT(restartAudioAndMidi()));
 
     connect(dialog, SIGNAL(sampleRateChanged(int)), controller, SLOT(setSampleRate(int)));
     connect(dialog, SIGNAL(bufferSizeChanged(int)), controller, SLOT(setBufferSize(int)));
 
-    connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), dialog, SLOT(populateVstTab()));
+    connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), dialog, SLOT(
+                populateVstTab()));
     connect(controller->getPluginFinder(), SIGNAL(scanStarted()), dialog, SLOT(clearVstList()));
 
-    connect(dialog, SIGNAL(vstScanDirRemoved(const QString &)), controller, SLOT(removePluginsScanPath(const QString &)));
-    connect(dialog, SIGNAL(vstScanDirAdded(const QString &)), controller, SLOT(addPluginsScanPath(const QString &)));
+    connect(dialog, SIGNAL(vstScanDirRemoved(const QString &)), controller,
+            SLOT(removePluginsScanPath(const QString &)));
+    connect(dialog, SIGNAL(vstScanDirAdded(const QString &)), controller,
+            SLOT(addPluginsScanPath(const QString &)));
 
-    connect(dialog, SIGNAL(vstPluginAddedInBlackList(const QString &)), controller, SLOT(addBlackVstToSettings(const QString &)));
-    connect(dialog, SIGNAL(vstPluginRemovedFromBlackList(const QString &)), controller, SLOT(removeBlackVstFromSettings(const QString &)));
+    connect(dialog, SIGNAL(vstPluginAddedInBlackList(const QString &)), controller,
+            SLOT(addBlackVstToSettings(const QString &)));
+    connect(dialog, SIGNAL(vstPluginRemovedFromBlackList(const QString &)), controller,
+            SLOT(removeBlackVstFromSettings(const QString &)));
 
     connect(dialog, SIGNAL(startingFullPluginsScan()), controller, SLOT(scanAllPlugins()));
     connect(dialog, SIGNAL(startingOnlyNewPluginsScan()), controller, SLOT(scanOnlyNewPlugins()));
 
-    connect(dialog, SIGNAL(openingExternalAudioControlPanel()), controller, SLOT(openExternalAudioControlPanel()));
+    connect(dialog, SIGNAL(openingExternalAudioControlPanel()), controller,
+            SLOT(openExternalAudioControlPanel()));
 
     return dialog;
 }

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -312,6 +312,8 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     connect(dialog, SIGNAL(sampleRateChanged(int)), controller, SLOT(setSampleRate(int)));
     connect(dialog, SIGNAL(bufferSizeChanged(int)), controller, SLOT(setBufferSize(int)));
 
+    connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), dialog, SLOT(populateVstTab()));
+
     return dialog;
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -303,20 +303,16 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
 
     // setup standalone specific signals
     connect(dialog,
-            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int, int, int)),
+            SIGNAL(ioPreferencesChanged(QList<bool>,int,int,int,int,int)),
             this,
-            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int, int, int)));
+            SLOT(setGlobalPreferences(QList<bool>,int,int,int,int,int)));
 
     connect(dialog, SIGNAL(rejected()), this, SLOT(restartAudioAndMidi()));
 
-    connect(dialog, SIGNAL(sampleRateChanged(int)), this, SLOT(setSampleRate(int)));
+    connect(dialog, SIGNAL(sampleRateChanged(int)), controller, SLOT(setSampleRate(int)));
+    connect(dialog, SIGNAL(bufferSizeChanged(int)), controller, SLOT(setBufferSize(int)));
 
     return dialog;
-}
-
-void MainWindowStandalone::setSampleRate(int newSampleRate)
-{
-    controller->setSampleRate(newSampleRate);
 }
 
 void MainWindowStandalone::restartAudioAndMidi()
@@ -357,18 +353,17 @@ void MainWindowStandalone::handleServerConnectionError(const QString &msg)
 
 void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsStatus,
                                                 int audioDevice, int firstIn, int lastIn,
-                                                int firstOut, int lastOut,
-                                                int bufferSize)
+                                                int firstOut, int lastOut)
 {
     Audio::AudioDriver *audioDriver = controller->getAudioDriver();
 
 #ifdef Q_OS_WIN
-    audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut, bufferSize);
+    audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut);
 #endif
 #ifdef Q_OS_MACX
-    audioDriver->setProperties(bufferSize);
+    audioDriver->setProperties();
 #endif
-    controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, bufferSize, midiInputsStatus);
+    controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, midiInputsStatus);
 
     Midi::MidiDriver *midiDriver = controller->getMidiDriver();
     midiDriver->setInputDevicesStatus(midiInputsStatus);

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -296,7 +296,8 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     audioDriver->stop(true);    // asking audio driver to refresh the devices list
     midiDriver->stop();
 
-    StandalonePreferencesDialog *dialog = new StandalonePreferencesDialog(controller, this);
+    bool showAudioControlPanelButton = controller->getAudioDriver()->hasControlPanel();
+    StandalonePreferencesDialog *dialog = new StandalonePreferencesDialog(controller, this, showAudioControlPanelButton);
 
     // setup signals related with recording
     MainWindow::setupPreferencesDialogSignals(dialog);

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -380,12 +380,8 @@ void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsSta
 {
     Audio::AudioDriver *audioDriver = controller->getAudioDriver();
 
-#ifdef Q_OS_WIN
     audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut);
-#endif
-#ifdef Q_OS_MACX
-    audioDriver->setProperties();
-#endif
+
     controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, midiInputsStatus);
 
     Midi::MidiDriver *midiDriver = controller->getMidiDriver();

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -380,8 +380,7 @@ void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsSta
 {
     Audio::AudioDriver *audioDriver = controller->getAudioDriver();
 
-    audioDriver->setProperties(audioDevice, firstIn, lastIn, firstOut, lastOut);
-
+    audioDriver->setProperties(firstIn, lastIn, firstOut, lastOut);
     controller->storeIOSettings(firstIn, lastIn, firstOut, lastOut, audioDevice, midiInputsStatus);
 
     Midi::MidiDriver *midiDriver = controller->getMidiDriver();

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -24,7 +24,8 @@ MainWindowStandalone::MainWindowStandalone(MainControllerStandalone *mainControl
     initializePluginFinder();
 }
 
-void MainWindowStandalone::setupShortcuts(){
+void MainWindowStandalone::setupShortcuts()
+{
     ui.actionAudioPreferences->setShortcut(QKeySequence(Qt::Key_F5));
     ui.actionMidiPreferences->setShortcut(QKeySequence(Qt::Key_F6));
     ui.actionVstPreferences->setShortcut(QKeySequence(Qt::Key_F7));
@@ -42,9 +43,12 @@ void MainWindowStandalone::setupSignals()
     Q_ASSERT(pluginFinder);
     connect(pluginFinder, SIGNAL(scanStarted()), this, SLOT(showPluginScanDialog()));
     connect(pluginFinder, SIGNAL(scanFinished(bool)), this, SLOT(hidePluginScanDialog(bool)));
-    connect(pluginFinder, SIGNAL(badPluginDetected(QString)), this, SLOT(addPluginToBlackList(QString)));
-    connect(pluginFinder, SIGNAL(pluginScanFinished(QString, QString, QString)), this, SLOT(addFoundedPlugin(QString, QString, QString)));
-    connect(pluginFinder, SIGNAL(pluginScanStarted(QString)), this, SLOT(setCurrentScanningPlugin(QString)));
+    connect(pluginFinder, SIGNAL(badPluginDetected(QString)), this,
+            SLOT(addPluginToBlackList(QString)));
+    connect(pluginFinder, SIGNAL(pluginScanFinished(QString, QString, QString)), this,
+            SLOT(addFoundedPlugin(QString, QString, QString)));
+    connect(pluginFinder, SIGNAL(pluginScanStarted(QString)), this,
+            SLOT(setCurrentScanningPlugin(QString)));
 }
 
 void MainWindowStandalone::initialize()
@@ -113,7 +117,8 @@ void MainWindowStandalone::addPluginToBlackList(const QString &pluginPath)
     controller->addBlackVstToSettings(pluginPath);
 }
 
-void MainWindowStandalone::addFoundedPlugin(const QString &name, const QString &group, const QString &path)
+void MainWindowStandalone::addFoundedPlugin(const QString &name, const QString &group,
+                                            const QString &path)
 {
     Q_UNUSED(path);
     Q_UNUSED(group);
@@ -174,13 +179,15 @@ void MainWindowStandalone::sanitizeSubchannelInputSelections(LocalTrackView *sub
     }
 }
 
-void MainWindowStandalone::restoreLocalSubchannelPluginsList(LocalTrackViewStandalone *subChannelView, const Subchannel &subChannel)
+void MainWindowStandalone::restoreLocalSubchannelPluginsList(
+    LocalTrackViewStandalone *subChannelView, const Subchannel &subChannel)
 {
     // create the plugins list
     foreach (const Persistence::Plugin &plugin, subChannel.getPlugins()) {
         QString pluginName = Audio::PluginDescriptor::getPluginNameFromPath(plugin.path);
         Audio::PluginDescriptor descriptor(pluginName, "VST", plugin.path);
-        Audio::Plugin *pluginInstance = controller->addPlugin(subChannelView->getInputIndex(), descriptor);
+        Audio::Plugin *pluginInstance = controller->addPlugin(
+            subChannelView->getInputIndex(), descriptor);
         if (pluginInstance) {
             try{
                 pluginInstance->restoreFromSerializedData(plugin.data);
@@ -230,7 +237,8 @@ LocalInputTrackSettings MainWindowStandalone::getInputsSettings() const
 
     // recreate the settings including the plugins
     LocalInputTrackSettings settings;
-    QList<LocalTrackGroupViewStandalone *> groups = getLocalChannels<LocalTrackGroupViewStandalone *>();
+    QList<LocalTrackGroupViewStandalone *> groups
+        = getLocalChannels<LocalTrackGroupViewStandalone *>();
     Q_ASSERT(groups.size() == baseSettings.channels.size());
 
     int channelID = 0;
@@ -241,7 +249,8 @@ LocalInputTrackSettings MainWindowStandalone::getInputsSettings() const
         Channel newChannel = channel;
         newChannel.subChannels.clear();
         int subChannelID = 0;
-        QList<LocalTrackViewStandalone *> trackViews = trackGroupView->getTracks<LocalTrackViewStandalone *>();
+        QList<LocalTrackViewStandalone *> trackViews
+            = trackGroupView->getTracks<LocalTrackViewStandalone *>();
         foreach (Subchannel subchannel, channel.subChannels) {
             Subchannel newSubChannel = subchannel;
             LocalTrackViewStandalone *trackView = trackViews.at(subChannelID);
@@ -275,40 +284,45 @@ void MainWindowStandalone::closeEvent(QCloseEvent *e)
         trackGroup->closePluginsWindows();
 }
 
-//+++++++++++++++++++=+
-//void MainWindowStandalone::showPreferencesDialog(int initialTab)
-//{
-
-//    Midi::MidiDriver *midiDriver = controller->getMidiDriver();
-//    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
-//    if (audioDriver)
-//        audioDriver->stop(true);//asking audio driver to refresh the devices list
-//    if (midiDriver)
-//        midiDriver->stop();
-
-//    StandalonePreferencesDialog dialog(controller, this);
-//    dialog.initialize(initialTab);
-
-//    connect(&dialog,
-//            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int, int, int)),
-//            this,
-//            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int, int, int)));
-
-//    int result = dialog.exec();
-//    if (result == QDialog::Rejected) {
-//        if (midiDriver)
-//            midiDriver->start(controller->getSettings().getMidiInputDevicesStatus());// restart audio and midi drivers if user cancel the preferences menu
-//        if (audioDriver)
-//            audioDriver->start();
-//    }
-//    /** audio driver parameters are changed in on_IOPropertiesChanged. This slot is always invoked when AudioIODialog is closed.*/
-//}
-
 PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
 {
-    PreferencesDialog * dialog = new StandalonePreferencesDialog(controller, this);
-    setupPreferencesDialogSignals(dialog);
+    // stop midi and audio before show the preferences dialog
+    Midi::MidiDriver *midiDriver = controller->getMidiDriver();
+    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
+
+    Q_ASSERT(midiDriver);
+    Q_ASSERT(audioDriver);
+
+    audioDriver->stop(true);    // asking audio driver to refresh the devices list
+    midiDriver->stop();
+
+    StandalonePreferencesDialog *dialog = new StandalonePreferencesDialog(controller, this);
+
+    // setup signals related with recording
+    MainWindow::setupPreferencesDialogSignals(dialog);
+
+    // setup standalone specific signals
+    connect(dialog,
+            SIGNAL(ioPreferencesChanged(QList<bool>, int, int, int, int, int, int, int)),
+            this,
+            SLOT(setGlobalPreferences(QList<bool>, int, int, int, int, int, int, int)));
+
+    connect(dialog, SIGNAL(rejected()), this, SLOT(restartAudioAndMidi()));
+
     return dialog;
+}
+
+void MainWindowStandalone::restartAudioAndMidi()
+{
+    // restart audio and midi drivers when user is cancelling the preferences dialog
+    Midi::MidiDriver *midiDriver = controller->getMidiDriver();
+    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
+
+    Q_ASSERT(midiDriver);
+    Q_ASSERT(audioDriver);
+
+    midiDriver->start(controller->getSettings().getMidiInputDevicesStatus());
+    audioDriver->start();
 }
 
 // ++++++++++++++++++++++
@@ -334,9 +348,10 @@ void MainWindowStandalone::handleServerConnectionError(const QString &msg)
     controller->quit();
 }
 
-void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsStatus, int audioDevice,
-                                                int firstIn, int lastIn, int firstOut, int lastOut,
-                                                int sampleRate, int bufferSize)
+void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsStatus,
+                                                int audioDevice, int firstIn, int lastIn,
+                                                int firstOut, int lastOut, int sampleRate,
+                                                int bufferSize)
 {
     Audio::AudioDriver *audioDriver = controller->getAudioDriver();
 
@@ -355,11 +370,12 @@ void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsSta
 
     controller->updateInputTracksRange();
 
-    foreach (LocalTrackGroupViewStandalone *channel, getLocalChannels<LocalTrackGroupViewStandalone *>())
+    foreach (LocalTrackGroupViewStandalone *channel,
+             getLocalChannels<LocalTrackGroupViewStandalone *>())
         channel->refreshInputSelectionNames();
 
     midiDriver->start(midiInputsStatus);
-    if(!audioDriver->start()){
+    if (!audioDriver->start()) {
         qCritical() << "Error starting audio device";
         QMessageBox::warning(this, "Audio error!",
                              "The audio device can't be started! Please check your audio device and try restart Jamtaba!");
@@ -370,7 +386,8 @@ void MainWindowStandalone::setGlobalPreferences(const QList<bool> &midiInputsSta
 // input selection changed by user or by system
 void MainWindowStandalone::refreshTrackInputSelection(int inputTrackIndex)
 {
-    foreach (LocalTrackGroupViewStandalone *channel, getLocalChannels<LocalTrackGroupViewStandalone *>())
+    foreach (LocalTrackGroupViewStandalone *channel,
+             getLocalChannels<LocalTrackGroupViewStandalone *>())
         channel->refreshInputSelectionName(inputTrackIndex);
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/Client/src/Standalone/gui/MainWindowStandalone.cpp
@@ -325,6 +325,8 @@ PreferencesDialog *MainWindowStandalone::createPreferencesDialog()
     connect(dialog, SIGNAL(startingFullPluginsScan()), controller, SLOT(scanAllPlugins()));
     connect(dialog, SIGNAL(startingOnlyNewPluginsScan()), controller, SLOT(scanOnlyNewPlugins()));
 
+    connect(dialog, SIGNAL(openingExternalAudioControlPanel()), controller, SLOT(openExternalAudioControlPanel()));
+
     return dialog;
 }
 

--- a/Client/src/Standalone/gui/MainWindowStandalone.h
+++ b/Client/src/Standalone/gui/MainWindowStandalone.h
@@ -59,6 +59,8 @@ private slots:
 
     void closePluginScanDialog();
 
+    void restartAudioAndMidi();
+
 private:
     MainControllerStandalone *controller;
     QScopedPointer<PluginScanDialog> pluginScanDialog;

--- a/Client/src/Standalone/gui/MainWindowStandalone.h
+++ b/Client/src/Standalone/gui/MainWindowStandalone.h
@@ -45,7 +45,7 @@ protected slots: //TODO change to private slots?
     void handleServerConnectionError(const QString &msg);
 
     void setGlobalPreferences(const QList<bool> &, int audioDevice, int firstIn, int lastIn, int firstOut,
-                              int lastOut, int bufferSize);
+                              int lastOut);
 
     // plugin finder
     void showPluginScanDialog();
@@ -60,8 +60,6 @@ private slots:
     void closePluginScanDialog();
 
     void restartAudioAndMidi();
-
-    void setSampleRate(int newSampleRate);
 
 private:
     MainControllerStandalone *controller;

--- a/Client/src/Standalone/gui/MainWindowStandalone.h
+++ b/Client/src/Standalone/gui/MainWindowStandalone.h
@@ -33,13 +33,13 @@ protected:
 
     NinjamRoomWindow *createNinjamWindow(const Login::RoomInfo &, MainController *) override;
 
-    void showPreferencesDialog(int initialTab) override;
-
     LocalTrackGroupViewStandalone *createLocalTrackGroupView(int channelGroupIndex) override;
 
     void initializeLocalSubChannel(LocalTrackView *subChannelView, const Persistence::Subchannel &subChannel) override;
 
     void restoreLocalSubchannelPluginsList(LocalTrackViewStandalone *subChannelView, const Persistence::Subchannel &subChannel);
+
+    PreferencesDialog *createPreferencesDialog() override;
 
 protected slots: //TODO change to private slots?
     void handleServerConnectionError(const QString &msg);

--- a/Client/src/Standalone/gui/MainWindowStandalone.h
+++ b/Client/src/Standalone/gui/MainWindowStandalone.h
@@ -45,7 +45,7 @@ protected slots: //TODO change to private slots?
     void handleServerConnectionError(const QString &msg);
 
     void setGlobalPreferences(const QList<bool> &, int audioDevice, int firstIn, int lastIn, int firstOut,
-                              int lastOut, int sampleRate, int bufferSize);
+                              int lastOut, int bufferSize);
 
     // plugin finder
     void showPluginScanDialog();
@@ -60,6 +60,8 @@ private slots:
     void closePluginScanDialog();
 
     void restartAudioAndMidi();
+
+    void setSampleRate(int newSampleRate);
 
 private:
     MainControllerStandalone *controller;

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -84,8 +84,6 @@ void StandalonePreferencesDialog::setupSignals()
     connect(ui->ButtonVST_RemFromBlkList, SIGNAL(clicked(bool)), this,
             SLOT(removeBlackListedPlugins()));
 
-    connect(controller->getPluginFinder(), SIGNAL(scanFinished(bool)), this,
-            SLOT(populateVstTab()));
 }
 
 void StandalonePreferencesDialog::addVstScanFolder()

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -142,7 +142,7 @@ void StandalonePreferencesDialog::updateBlackBox(QString path, bool add)
         QString str = ui->blackListWidget->toPlainText();
         if (str.contains(path)) {
             ui->blackListWidget->clear();
-            controller->removeBlackVst(str.indexOf(path));
+            //controller->removeBlackVstFromSettings(str.indexOf(path));
             QStringList badPlugins = controller->getSettings().getBlackListedPlugins();
             foreach (const QString &badPlugin, badPlugins)
                 ui->blackListWidget->appendPlainText(badPlugin);
@@ -185,14 +185,13 @@ void StandalonePreferencesDialog::scanNewPlugins()
     controller->scanPlugins(true);
 }
 
-// ADD A VST IN BLACKLIST
+// open a dialog to add a vst in the blacklist
 void StandalonePreferencesDialog::addBlackListedPlugins()
 {
-    QFileDialog vstDialog(this, "Add Vst(s) to BlackBox ...");
+    QFileDialog vstDialog(this, "Add Vst(s) to Black list ...");
     vstDialog.setNameFilter("Dll(*.dll)");// TODO in mac the extension is .vst
-    QStringList foldersToScan = controller->getSettings().getVstScanFolders();
-    if (!foldersToScan.isEmpty())
-        vstDialog.setDirectory(foldersToScan.first());
+    if (!settings.getVstScanFolders().isEmpty())
+        vstDialog.setDirectory(settings.getVstScanFolders().first());
     vstDialog.setAcceptMode(QFileDialog::AcceptOpen);
     vstDialog.setFileMode(QFileDialog::ExistingFiles);
 
@@ -200,7 +199,7 @@ void StandalonePreferencesDialog::addBlackListedPlugins()
         QStringList vstNames = vstDialog.selectedFiles();
         foreach (const QString &string, vstNames) {
             updateBlackBox(string, true);// add to
-            controller->addBlackVstToSettings(string);
+            emit vstPluginAddedInBlackList(string);
         }
     }
 }
@@ -209,7 +208,7 @@ void StandalonePreferencesDialog::removeBlackListedPlugins()
 {
     QFileDialog vstDialog(this, "Remove Vst(s) from Black List ...");
     vstDialog.setNameFilter("Dll(*.dll)");// TODO mac extension is .vst
-    QStringList foldersToScan = controller->getSettings().getVstScanFolders();
+    QStringList foldersToScan = settings.getVstScanFolders();
     if (!foldersToScan.isEmpty())
         vstDialog.setDirectory(foldersToScan.first());
     vstDialog.setAcceptMode(QFileDialog::AcceptOpen);
@@ -217,8 +216,8 @@ void StandalonePreferencesDialog::removeBlackListedPlugins()
     if (vstDialog.exec()) {
         QStringList vstNames = vstDialog.selectedFiles();
         foreach (const QString &string, vstNames) {
+            emit vstPluginRemovedFromBlackList(string);
             updateBlackBox(string, false);// Remove from
-            controller->removeBlackVst(0);// index
         }
     }
 }

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -93,7 +93,9 @@ void StandalonePreferencesDialog::addVstScanFolder()
     fileDialog.setFileMode(QFileDialog::DirectoryOnly);
     if (fileDialog.exec()) {
         QDir dir = fileDialog.directory();
-        addVstFolderToScan(dir.absolutePath());
+        QString newFolder = dir.absolutePath();
+        createWidgetsToNewFolder(newFolder);
+        emit vstScanDirAdded(newFolder);
     }
 }
 
@@ -120,9 +122,10 @@ void StandalonePreferencesDialog::removeVstscanFolder()
         }
     }
     if (panelToDelete) {
-        controller->removePluginsScanPath(panelToDelete->getScanFolder());
         ui->panelScanFolders->layout()->removeWidget(panelToDelete);
+        emit vstScanDirRemoved(panelToDelete->getScanFolder());
         panelToDelete->deleteLater();
+
     }
 }
 
@@ -152,12 +155,6 @@ void StandalonePreferencesDialog::createWidgetsToNewFolder(QString path)
     ScanFolderPanel *panel = new ScanFolderPanel(path);
     connect(panel->getRemoveButton(), SIGNAL(clicked(bool)), this, SLOT(removeVstscanFolder()));
     ui->panelScanFolders->layout()->addWidget(panel);
-}
-
-void StandalonePreferencesDialog::addVstFolderToScan(QString folder)
-{
-    createWidgetsToNewFolder(folder);
-    controller->addPluginsScanPath(folder);
 }
 
 // clear the vst cache and run a complete scan

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -26,6 +26,15 @@ StandalonePreferencesDialog::StandalonePreferencesDialog(Controller::MainControl
     ui->groupBoxInputs->setVisible(false);
     ui->groupBoxOutputs->setVisible(false);
 #endif
+
+    connect( ui->comboSampleRate, SIGNAL(activated(int)), this, SLOT(notifySampleRateChanged()));
+}
+
+
+void StandalonePreferencesDialog::notifySampleRateChanged()
+{
+    int newSampleRate = ui->comboSampleRate->currentData().toInt();
+    emit sampleRateChanged(newSampleRate);
 }
 
 void StandalonePreferencesDialog::initialize(int initialTab, const Persistence::Settings &settings)
@@ -361,6 +370,7 @@ void StandalonePreferencesDialog::populateSampleRateCombo()
 
     ui->comboSampleRate->setCurrentText(QString::number(audioDriver->getSampleRate()));
     ui->comboSampleRate->setEnabled(!sampleRates.isEmpty());
+
 }
 
 void StandalonePreferencesDialog::populateBufferSizeCombo()

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -52,7 +52,7 @@ void StandalonePreferencesDialog::initialize(int initialTab, const Persistence::
 
 void StandalonePreferencesDialog::populateAllTabs()
 {
-    populateAudioTab();
+    populateAudioTab(controller->getAudioDriver());
     populateMidiTab();
     populateVstTab();
     populateRecordingTab();
@@ -70,8 +70,7 @@ void StandalonePreferencesDialog::setupSignals()
     connect(ui->comboFirstOutput, SIGNAL(currentIndexChanged(int)), this,
             SLOT(populateLastOutputCombo()));
 
-    connect(ui->buttonControlPanel, SIGNAL(clicked(bool)), this,
-            SLOT(openExternalAudioControlPanel()));
+    connect(ui->buttonControlPanel, SIGNAL(clicked(bool)), this, SIGNAL(openingExternalAudioControlPanel()));
 
     connect(ui->buttonAddVstScanFolder, SIGNAL(clicked(bool)), this, SLOT(addVstScanFolder()));
 
@@ -250,9 +249,9 @@ void StandalonePreferencesDialog::populateMidiTab()
     }
 }
 
-void StandalonePreferencesDialog::populateAudioTab()
+void StandalonePreferencesDialog::populateAudioTab(Audio::AudioDriver *audioDriver)
 {
-    populateAsioDriverCombo();
+    populateAsioDriverCombo(audioDriver);
     populateFirstInputCombo();
     populateFirstOutputCombo();
     populateSampleRateCombo();
@@ -261,9 +260,8 @@ void StandalonePreferencesDialog::populateAudioTab()
     ui->buttonControlPanel->setVisible(showAudioDriverControlPanelButton);
 }
 
-void StandalonePreferencesDialog::populateAsioDriverCombo()
+void StandalonePreferencesDialog::populateAsioDriverCombo(Audio::AudioDriver *audioDriver)
 {
-    Audio::AudioDriver *audioDriver = controller->getAudioDriver();
     int devices = audioDriver->getDevicesCount();
     ui->comboAudioDevice->clear();
     for (int d = 0; d < devices; d++) {
@@ -419,7 +417,7 @@ void StandalonePreferencesDialog::selectTab(int index)
 {
     switch (index) {
     case 0:
-        populateAudioTab();
+        populateAudioTab(controller->getAudioDriver());
         break;
     case 1:
         populateMidiTab();
@@ -433,9 +431,3 @@ void StandalonePreferencesDialog::selectTab(int index)
     }
 }
 
-void StandalonePreferencesDialog::openExternalAudioControlPanel()
-{
-    AudioDriver *audioDriver = controller->getAudioDriver();
-    if (audioDriver->hasControlPanel())// just in case
-        audioDriver->openControlPanel((void *)parentWidget()->winId());
-}

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -27,9 +27,15 @@ StandalonePreferencesDialog::StandalonePreferencesDialog(Controller::MainControl
     ui->groupBoxOutputs->setVisible(false);
 #endif
 
-    connect( ui->comboSampleRate, SIGNAL(activated(int)), this, SLOT(notifySampleRateChanged()));
+    connect(ui->comboSampleRate, SIGNAL(activated(int)), this, SLOT(notifySampleRateChanged()));
+    connect(ui->comboBufferSize, SIGNAL(activated(int)), this, SLOT(notifyBufferSizeChanged()));
 }
 
+void StandalonePreferencesDialog::notifyBufferSizeChanged()
+{
+    int newBufferSize = ui->comboBufferSize->currentData().toInt();
+    emit bufferSizeChanged(newBufferSize);
+}
 
 void StandalonePreferencesDialog::notifySampleRateChanged()
 {
@@ -404,8 +410,6 @@ void StandalonePreferencesDialog::accept()
     int lastIn = ui->comboLastInput->currentData().toInt();
     int firstOut = ui->comboFirstOutput->currentData().toInt();
     int lastOut = ui->comboLastOutput->currentData().toInt();
-    int sampleRate = ui->comboSampleRate->currentText().toInt();
-    int bufferSize = ui->comboBufferSize->currentText().toInt();
 
     // build midi inputs devices status
     QList<bool> midiInputsStatus;
@@ -415,8 +419,7 @@ void StandalonePreferencesDialog::accept()
 
     QDialog::accept();
 
-    emit ioPreferencesChanged(midiInputsStatus, selectedAudioDevice, firstIn, lastIn, firstOut,
-                              lastOut, sampleRate, bufferSize);
+    emit ioPreferencesChanged(midiInputsStatus, selectedAudioDevice, firstIn, lastIn, firstOut, lastOut);
 }
 
 void StandalonePreferencesDialog::populateVstTab()

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -154,6 +154,7 @@ void StandalonePreferencesDialog::createWidgetsToNewFolder(QString path)
     ScanFolderPanel *panel = new ScanFolderPanel(path);
     connect(panel->getRemoveButton(), SIGNAL(clicked(bool)), this, SLOT(removeVstscanFolder()));
     ui->panelScanFolders->layout()->addWidget(panel);
+    ui->panelScanFolders->layout()->setAlignment(panel, Qt::AlignTop);
 }
 
 void StandalonePreferencesDialog::clearVstList()

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -76,12 +76,12 @@ void StandalonePreferencesDialog::setupSignals()
 
     connect(ui->buttonClearVstAndScan, SIGNAL(clicked(bool)), this, SIGNAL(startingFullPluginsScan()));
 
-    connect(ui->ButtonVst_Refresh, SIGNAL(clicked(bool)), this, SIGNAL(startingOnlyNewPluginsScan()));
+    connect(ui->buttonVstRefresh, SIGNAL(clicked(bool)), this, SIGNAL(startingOnlyNewPluginsScan()));
 
-    connect(ui->ButtonVST_AddToBlackList, SIGNAL(clicked(bool)), this,
+    connect(ui->buttonAddVstToBlackList, SIGNAL(clicked(bool)), this,
             SLOT(addBlackListedPlugins()));
 
-    connect(ui->ButtonVST_RemFromBlkList, SIGNAL(clicked(bool)), this,
+    connect(ui->buttonRemoveVstFromBlackList, SIGNAL(clicked(bool)), this,
             SLOT(removeBlackListedPlugins()));
 
 }

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -74,9 +74,9 @@ void StandalonePreferencesDialog::setupSignals()
 
     connect(ui->buttonAddVstScanFolder, SIGNAL(clicked(bool)), this, SLOT(addVstScanFolder()));
 
-    connect(ui->buttonClearVstAndScan, SIGNAL(clicked(bool)), this, SLOT(scansFully()));
+    connect(ui->buttonClearVstAndScan, SIGNAL(clicked(bool)), this, SIGNAL(startingFullPluginsScan()));
 
-    connect(ui->ButtonVst_Refresh, SIGNAL(clicked(bool)), this, SLOT(scanNewPlugins()));
+    connect(ui->ButtonVst_Refresh, SIGNAL(clicked(bool)), this, SIGNAL(startingOnlyNewPluginsScan()));
 
     connect(ui->ButtonVST_AddToBlackList, SIGNAL(clicked(bool)), this,
             SLOT(addBlackListedPlugins()));
@@ -142,7 +142,6 @@ void StandalonePreferencesDialog::updateBlackBox(QString path, bool add)
         QString str = ui->blackListWidget->toPlainText();
         if (str.contains(path)) {
             ui->blackListWidget->clear();
-            //controller->removeBlackVstFromSettings(str.indexOf(path));
             QStringList badPlugins = controller->getSettings().getBlackListedPlugins();
             foreach (const QString &badPlugin, badPlugins)
                 ui->blackListWidget->appendPlainText(badPlugin);
@@ -157,32 +156,9 @@ void StandalonePreferencesDialog::createWidgetsToNewFolder(QString path)
     ui->panelScanFolders->layout()->addWidget(panel);
 }
 
-// clear the vst cache and run a complete scan
-void StandalonePreferencesDialog::scansFully()
+void StandalonePreferencesDialog::clearVstList()
 {
-    Q_ASSERT(controller);
-
-    // save the config file before start scanning
-    controller->saveLastUserSettings(settings.getInputsSettings());
-
-    // clear
-    controller->clearPluginsCache();
     ui->vstListWidget->clear();
-
-    // scan
-    controller->scanPlugins();
-}
-
-// Refresh vsts scanning only the new plugins
-void StandalonePreferencesDialog::scanNewPlugins()
-{
-    Q_ASSERT(controller);
-
-    // save the config file before start scanning
-    controller->saveLastUserSettings(settings.getInputsSettings());
-
-    // scan only new plugins
-    controller->scanPlugins(true);
 }
 
 // open a dialog to add a vst in the blacklist
@@ -198,8 +174,8 @@ void StandalonePreferencesDialog::addBlackListedPlugins()
     if (vstDialog.exec()) {
         QStringList vstNames = vstDialog.selectedFiles();
         foreach (const QString &string, vstNames) {
-            updateBlackBox(string, true);// add to
             emit vstPluginAddedInBlackList(string);
+            updateBlackBox(string, true);// add to
         }
     }
 }

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -15,9 +15,10 @@ using namespace Controller;
 
 // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++=
 
-StandalonePreferencesDialog::StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent) :
+StandalonePreferencesDialog::StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent, bool showAudioControlPanelButton) :
     PreferencesDialog(parent),
-    controller(mainController)
+    controller(mainController),
+    showAudioDriverControlPanelButton(showAudioControlPanelButton)
 {
 
 #ifdef Q_OS_MAC
@@ -257,7 +258,7 @@ void StandalonePreferencesDialog::populateAudioTab()
     populateSampleRateCombo();
     populateBufferSizeCombo();
 
-    ui->buttonControlPanel->setVisible(controller->getAudioDriver()->hasControlPanel());
+    ui->buttonControlPanel->setVisible(showAudioDriverControlPanelButton);
 }
 
 void StandalonePreferencesDialog::populateAsioDriverCombo()

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -18,7 +18,8 @@ using namespace Controller;
 StandalonePreferencesDialog::StandalonePreferencesDialog(
     Controller::MainControllerStandalone *mainController, MainWindow *mainWindow) :
     PreferencesDialog(mainWindow),
-    controller(mainController)
+    controller(mainController),
+    mainWindow(mainWindow)
 {
 #ifdef Q_OS_MAC
     ui->comboAudioDevice->setVisible(false);

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -17,7 +17,7 @@ using namespace Controller;
 
 StandalonePreferencesDialog::StandalonePreferencesDialog(
     Controller::MainControllerStandalone *mainController, MainWindow *mainWindow) :
-    PreferencesDialog(mainController, mainWindow),
+    PreferencesDialog(mainWindow),
     controller(mainController)
 {
 #ifdef Q_OS_MAC
@@ -28,9 +28,9 @@ StandalonePreferencesDialog::StandalonePreferencesDialog(
 #endif
 }
 
-void StandalonePreferencesDialog::initialize(int initialTab)
+void StandalonePreferencesDialog::initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings)
 {
-    PreferencesDialog::initialize();
+    PreferencesDialog::initialize(initialTab, recordingSettings);
     ui->prefsTab->setCurrentIndex(initialTab);
 }
 
@@ -127,7 +127,7 @@ void StandalonePreferencesDialog::updateBlackBox(QString path, bool add)
         if (str.contains(path)) {
             ui->blackListWidget->clear();
             controller->removeBlackVst(str.indexOf(path));
-            QStringList badPlugins = mainController->getSettings().getBlackListedPlugins();
+            QStringList badPlugins = controller->getSettings().getBlackListedPlugins();
             foreach (const QString &badPlugin, badPlugins)
                 ui->blackListWidget->appendPlainText(badPlugin);
         }
@@ -414,9 +414,9 @@ void StandalonePreferencesDialog::accept()
 void StandalonePreferencesDialog::populateVstTab()
 {
     clearScanFolderWidgets();// remove all widgets before add the paths
-    QStringList scanFoldersList = mainController->getSettings().getVstScanFolders();
-    QStringList vstList = mainController->getSettings().getVstPluginsPaths();
-    QStringList blackVstList = mainController->getSettings().getBlackListedPlugins();
+    QStringList scanFoldersList = controller->getSettings().getVstScanFolders();
+    QStringList vstList = controller->getSettings().getVstPluginsPaths();
+    QStringList blackVstList = controller->getSettings().getBlackListedPlugins();
 
     // populate the paths
     foreach (const QString &scanFolder, scanFoldersList)
@@ -433,7 +433,7 @@ void StandalonePreferencesDialog::populateVstTab()
         updateBlackBox(path, true);// add vst
 }
 
-void StandalonePreferencesDialog::selectPreferencesTab(int index)
+void StandalonePreferencesDialog::selectTab(int index)
 {
     switch (index) {
     case 0:

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -266,8 +266,7 @@ void StandalonePreferencesDialog::populateAsioDriverCombo()
     int devices = audioDriver->getDevicesCount();
     ui->comboAudioDevice->clear();
     for (int d = 0; d < devices; d++) {
-        // using device index as userData in comboBox
-        ui->comboAudioDevice->addItem(audioDriver->getAudioDeviceName(d), d);
+        ui->comboAudioDevice->addItem(audioDriver->getAudioDeviceName(d), d);// using device index as userData in comboBox
     }
     ui->comboAudioDevice->setCurrentIndex(audioDriver->getAudioDeviceIndex());
 }

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -2,9 +2,9 @@
 
 #include "audio/core/AudioDriver.h"
 #include "MainControllerStandalone.h"
-#include "MainWindow.h"
 #include "gui/ScanFolderPanel.h"
 #include "QFileDialog"
+#include "persistence/Settings.h"
 
 /**
  This file contains the common/shared implementation for the Jamtaba plataforms (Win, Mac and Linux) in Standalone. In the Vst Plugin some details are different and implemented in the file VstPreferencesDialog.cpp.
@@ -15,12 +15,11 @@ using namespace Controller;
 
 // ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++=
 
-StandalonePreferencesDialog::StandalonePreferencesDialog(
-    Controller::MainControllerStandalone *mainController, MainWindow *mainWindow) :
-    PreferencesDialog(mainWindow),
-    controller(mainController),
-    mainWindow(mainWindow)
+StandalonePreferencesDialog::StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent) :
+    PreferencesDialog(parent),
+    controller(mainController)
 {
+
 #ifdef Q_OS_MAC
     ui->comboAudioDevice->setVisible(false);
     ui->asioDriverLabel->setVisible(false);
@@ -29,9 +28,9 @@ StandalonePreferencesDialog::StandalonePreferencesDialog(
 #endif
 }
 
-void StandalonePreferencesDialog::initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings)
+void StandalonePreferencesDialog::initialize(int initialTab, const Persistence::Settings &settings)
 {
-    PreferencesDialog::initialize(initialTab, recordingSettings);
+    PreferencesDialog::initialize(initialTab, settings);
     ui->prefsTab->setCurrentIndex(initialTab);
 }
 
@@ -152,10 +151,9 @@ void StandalonePreferencesDialog::addVstFolderToScan(QString folder)
 void StandalonePreferencesDialog::scansFully()
 {
     Q_ASSERT(controller);
-    Q_ASSERT(mainWindow);
 
     // save the config file before start scanning
-    controller->saveLastUserSettings(mainWindow->getInputsSettings());
+    controller->saveLastUserSettings(settings.getInputsSettings());
 
     // clear
     controller->clearPluginsCache();
@@ -169,10 +167,9 @@ void StandalonePreferencesDialog::scansFully()
 void StandalonePreferencesDialog::scanNewPlugins()
 {
     Q_ASSERT(controller);
-    Q_ASSERT(mainWindow);
 
     // save the config file before start scanning
-    controller->saveLastUserSettings(mainWindow->getInputsSettings());
+    controller->saveLastUserSettings(settings.getInputsSettings());
 
     // scan only new plugins
     controller->scanPlugins(true);
@@ -456,5 +453,5 @@ void StandalonePreferencesDialog::openExternalAudioControlPanel()
 {
     AudioDriver *audioDriver = controller->getAudioDriver();
     if (audioDriver->hasControlPanel())// just in case
-        audioDriver->openControlPanel((void *)mainWindow->winId());
+        audioDriver->openControlPanel((void *)parentWidget()->winId());
 }

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -12,7 +12,7 @@ class StandalonePreferencesDialog : public PreferencesDialog
 
 public:
     StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, MainWindow *mainWindow);
-    void initialize(int initialTab);
+    void initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings) override;
 
 public slots:
     void accept() override;
@@ -42,7 +42,7 @@ private slots:
     void populateVstTab();
 
 protected slots:
-    void selectPreferencesTab(int index) override;
+    void selectTab(int index) override;
 
 protected:
     void setupSignals() override;

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -3,14 +3,21 @@
 
 #include "PreferencesDialog.h"
 #include "ui_PreferencesDialog.h"
-#include "MainControllerStandalone.h"
+
+namespace Audio {
+class AudioDriver;
+}
+
+namespace Midi {
+class MidiDriver;
+}
 
 class StandalonePreferencesDialog : public PreferencesDialog
 {
     Q_OBJECT
 
 public:
-    StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent, bool showAudioControlPanelButton);
+    StandalonePreferencesDialog(QWidget *parent, bool showAudioControlPanelButton, Audio::AudioDriver *audioDriver, Midi::MidiDriver *midiDriver);
     void initialize(int initialTab, const Persistence::Settings &settings) override;
 
 public slots:
@@ -61,25 +68,26 @@ protected:
 
 private:
 
-    Controller::MainControllerStandalone* controller;
+    Audio::AudioDriver *audioDriver;
+    Midi::MidiDriver *midiDriver;
 
     void selectAudioTab();
     void selectMidiTab();
     void selectVstPluginsTab();
 
-    void populateAsioDriverCombo(Audio::AudioDriver *audioDriver);
+    void populateAsioDriverCombo();
     void populateFirstInputCombo();
     void populateFirstOutputCombo();
 
     void populateSampleRateCombo();
     void populateBufferSizeCombo();
-    void populateAudioTab(Audio::AudioDriver *audioDriver);
+    void populateAudioTab();
 
     void populateMidiTab();
 
     void createWidgetsToNewFolder(QString path);
     void updateVstList(QString path);
-    void updateBlackBox(QString path, bool add);
+    void updateBlackBox();
     void clearScanFolderWidgets();
 
     void clearWidgetLayout(QWidget* widget);

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -25,6 +25,9 @@ signals:
     void sampleRateChanged(int newSampleRate);
     void bufferSizeChanged(int newBufferSize);
 
+    void vstScanDirRemoved(const QString &scanDir);
+    void vstScanDirAdded(const QString &newDir);
+
 private slots:
     void addBlackListedPlugins();
     void removeBlackListedPlugins();
@@ -54,7 +57,7 @@ protected:
 
 private:
 
-    //Controller::MainControllerStandalone* controller;
+    Controller::MainControllerStandalone* controller;
 
     void selectAudioTab();
     void selectMidiTab();
@@ -70,7 +73,6 @@ private:
 
     void populateMidiTab();
 
-    void addVstFolderToScan(QString folder);
     void createWidgetsToNewFolder(QString path);
     void updateVstList(QString path);
     void updateBlackBox(QString path, bool add);

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -18,10 +18,10 @@ public slots:
 
 signals:
     void ioPreferencesChanged(QList<bool> midiInputsStatus, int selectedAudioDevice, int firstIn,
-                              int lastIn, int firstOut, int lastOut, int sampleRate,
-                              int bufferSize);
+                              int lastIn, int firstOut, int lastOut);
 
     void sampleRateChanged(int newSampleRate);
+    void bufferSizeChanged(int newBufferSize);
 
 private slots:
     void addBlackListedPlugins();
@@ -43,6 +43,7 @@ private slots:
     void populateVstTab();
 
     void notifySampleRateChanged();
+    void notifyBufferSizeChanged();
 
 protected slots:
     void selectTab(int index) override;

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -35,12 +35,11 @@ signals:
 
     void startingFullPluginsScan();
     void startingOnlyNewPluginsScan();
+    void openingExternalAudioControlPanel(); // asio control panel in windows
 
 private slots:
     void addBlackListedPlugins();
     void removeBlackListedPlugins();
-
-    void openExternalAudioControlPanel();// asio control panel in windows
 
     void addVstScanFolder();
     void removeVstscanFolder();
@@ -68,13 +67,13 @@ private:
     void selectMidiTab();
     void selectVstPluginsTab();
 
-    void populateAsioDriverCombo();
+    void populateAsioDriverCombo(Audio::AudioDriver *audioDriver);
     void populateFirstInputCombo();
     void populateFirstOutputCombo();
 
     void populateSampleRateCombo();
     void populateBufferSizeCombo();
-    void populateAudioTab();
+    void populateAudioTab(Audio::AudioDriver *audioDriver);
 
     void populateMidiTab();
 

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -51,6 +51,7 @@ protected:
 private:
 
     Controller::MainControllerStandalone* controller;
+    MainWindow *mainWindow;
 
     void selectAudioTab();
     void selectMidiTab();

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -3,7 +3,6 @@
 
 #include "PreferencesDialog.h"
 #include "ui_PreferencesDialog.h"
-#include "MainWindow.h"
 #include "MainControllerStandalone.h"
 
 class StandalonePreferencesDialog : public PreferencesDialog
@@ -11,8 +10,8 @@ class StandalonePreferencesDialog : public PreferencesDialog
     Q_OBJECT
 
 public:
-    StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, MainWindow *mainWindow);
-    void initialize(int initialTab, const Persistence::RecordingSettings &recordingSettings) override;
+    StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent);
+    void initialize(int initialTab, const Persistence::Settings &settings) override;
 
 public slots:
     void accept() override;
@@ -51,7 +50,6 @@ protected:
 private:
 
     Controller::MainControllerStandalone* controller;
-    MainWindow *mainWindow;
 
     void selectAudioTab();
     void selectMidiTab();

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -10,7 +10,7 @@ class StandalonePreferencesDialog : public PreferencesDialog
     Q_OBJECT
 
 public:
-    StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent);
+    StandalonePreferencesDialog(Controller::MainControllerStandalone *mainController, QWidget *parent, bool showAudioControlPanelButton);
     void initialize(int initialTab, const Persistence::Settings &settings) override;
 
 public slots:
@@ -84,6 +84,8 @@ private:
     void clearScanFolderWidgets();
 
     void clearWidgetLayout(QWidget* widget);
+
+    bool showAudioDriverControlPanelButton;
 
 };
 

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -21,6 +21,8 @@ signals:
                               int lastIn, int firstOut, int lastOut, int sampleRate,
                               int bufferSize);
 
+    void sampleRateChanged(int newSampleRate);
+
 private slots:
     void addBlackListedPlugins();
     void removeBlackListedPlugins();
@@ -39,6 +41,8 @@ private slots:
     void changeAudioDevice(int index);
 
     void populateVstTab();
+
+    void notifySampleRateChanged();
 
 protected slots:
     void selectTab(int index) override;

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -28,6 +28,9 @@ signals:
     void vstScanDirRemoved(const QString &scanDir);
     void vstScanDirAdded(const QString &newDir);
 
+    void vstPluginAddedInBlackList(const QString &pluginPath);
+    void vstPluginRemovedFromBlackList(const QString &pluginPath);
+
 private slots:
     void addBlackListedPlugins();
     void removeBlackListedPlugins();

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -16,6 +16,8 @@ public:
 public slots:
     void accept() override;
 
+    void populateVstTab();
+
 signals:
     void ioPreferencesChanged(QList<bool> midiInputsStatus, int selectedAudioDevice, int firstIn,
                               int lastIn, int firstOut, int lastOut);
@@ -40,8 +42,6 @@ private slots:
 
     void changeAudioDevice(int index);
 
-    void populateVstTab();
-
     void notifySampleRateChanged();
     void notifyBufferSizeChanged();
 
@@ -54,7 +54,7 @@ protected:
 
 private:
 
-    Controller::MainControllerStandalone* controller;
+    //Controller::MainControllerStandalone* controller;
 
     void selectAudioTab();
     void selectMidiTab();

--- a/Client/src/Standalone/gui/PreferencesDialogStandalone.h
+++ b/Client/src/Standalone/gui/PreferencesDialogStandalone.h
@@ -18,6 +18,8 @@ public slots:
 
     void populateVstTab();
 
+    void clearVstList();
+
 signals:
     void ioPreferencesChanged(QList<bool> midiInputsStatus, int selectedAudioDevice, int firstIn,
                               int lastIn, int firstOut, int lastOut);
@@ -31,12 +33,12 @@ signals:
     void vstPluginAddedInBlackList(const QString &pluginPath);
     void vstPluginRemovedFromBlackList(const QString &pluginPath);
 
+    void startingFullPluginsScan();
+    void startingOnlyNewPluginsScan();
+
 private slots:
     void addBlackListedPlugins();
     void removeBlackListedPlugins();
-
-    void scansFully();
-    void scanNewPlugins();
 
     void openExternalAudioControlPanel();// asio control panel in windows
 

--- a/Client/src/Standalone/gui/ScanFolderPanel.cpp
+++ b/Client/src/Standalone/gui/ScanFolderPanel.cpp
@@ -9,12 +9,19 @@ ScanFolderPanel::ScanFolderPanel(QString folder) :
     removeButton(nullptr),
     scanFolder(folder)
 {
+
+    setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+
     removeButton = new QPushButton(QIcon(":/images/less.png"), "");
     removeButton->setToolTip("Remove this folder from scanning");
+    removeButton->setSizePolicy(QSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed));
 
     QHBoxLayout *layout = new QHBoxLayout();
     this->setLayout(layout);
     layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(6);
     layout->addWidget(removeButton);
-    layout->addWidget(new QLabel(scanFolder, this), 1.0);
+    QLabel *label = new QLabel(scanFolder);
+    label->setSizePolicy(QSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed));
+    layout->addWidget(label, 1);
 }

--- a/Client/src/VstPlugin/MainWindowVST.cpp
+++ b/Client/src/VstPlugin/MainWindowVST.cpp
@@ -52,12 +52,10 @@ void MainWindowVST::setFullViewStatus(bool fullViewActivated)
     controller->resizePluginEditor(width(), height());
 }
 
-// ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
-void MainWindowVST::showPreferencesDialog(int initialTab)
+
+PreferencesDialog *MainWindowVST::createPreferencesDialog()
 {
-    Q_UNUSED(initialTab)
-    VstPreferencesDialog dialog(mainController, this);
-    dialog.initialize();
-    centerDialog(&dialog);
-    dialog.exec();
+    PreferencesDialog * dialog = new VstPreferencesDialog(this);
+    setupPreferencesDialogSignals(dialog);
+    return dialog;
 }

--- a/Client/src/VstPlugin/MainWindowVST.h
+++ b/Client/src/VstPlugin/MainWindowVST.h
@@ -21,12 +21,11 @@ protected:
     NinjamRoomWindowVST *createNinjamWindow(const Login::RoomInfo &, Controller::MainController *) override;
     void setFullViewStatus(bool fullViewActivated);
 
-    void showPreferencesDialog(int initialTab) override;
-
     void initializeLocalSubChannel(LocalTrackView *subChannelView, const Persistence::Subchannel &subChannel) override;
 
     void removeAllInputLocalTracks() override;
 
+    PreferencesDialog * createPreferencesDialog() override;
 private:
     bool firstChannelIsInitialized;
 

--- a/Client/src/VstPlugin/VstPreferencesDialog.cpp
+++ b/Client/src/VstPlugin/VstPreferencesDialog.cpp
@@ -1,7 +1,7 @@
 #include "VstPreferencesDialog.h"
 
-VstPreferencesDialog::VstPreferencesDialog(MainWindow *mainWindow) :
-    PreferencesDialog(mainWindow)
+VstPreferencesDialog::VstPreferencesDialog(QWidget *parent) :
+    PreferencesDialog(parent)
 {
     // in Vst plugin some preferences are not available
     // remove the first 3 tabs (audio, midi and VSTs)

--- a/Client/src/VstPlugin/VstPreferencesDialog.cpp
+++ b/Client/src/VstPlugin/VstPreferencesDialog.cpp
@@ -1,8 +1,7 @@
 #include "VstPreferencesDialog.h"
 
-VstPreferencesDialog::VstPreferencesDialog(Controller::MainController *mainController,
-                                           MainWindow *mainWindow) :
-    PreferencesDialog(mainController, mainWindow)
+VstPreferencesDialog::VstPreferencesDialog(MainWindow *mainWindow) :
+    PreferencesDialog(mainWindow)
 {
     // in Vst plugin some preferences are not available
     // remove the first 3 tabs (audio, midi and VSTs)
@@ -11,7 +10,7 @@ VstPreferencesDialog::VstPreferencesDialog(Controller::MainController *mainContr
     ui->prefsTab->removeTab(0);
 }
 
-void VstPreferencesDialog::selectPreferencesTab(int index)
+void VstPreferencesDialog::selectTab(int index)
 {
     Q_UNUSED(index)
     populateRecordingTab();//only the recording tab is available in VST plugin

--- a/Client/src/VstPlugin/VstPreferencesDialog.h
+++ b/Client/src/VstPlugin/VstPreferencesDialog.h
@@ -10,10 +10,10 @@ class VstPreferencesDialog : public PreferencesDialog
     Q_OBJECT
 
 public:
-    VstPreferencesDialog(Controller::MainController *mainController, MainWindow *mainWindow);
+    VstPreferencesDialog(MainWindow *mainWindow);
 
 protected slots:
-    void selectPreferencesTab(int index) override;
+    void selectTab(int index) override;
 
 protected:
     void populateAllTabs() override;

--- a/Client/src/VstPlugin/VstPreferencesDialog.h
+++ b/Client/src/VstPlugin/VstPreferencesDialog.h
@@ -3,14 +3,13 @@
 
 #include "PreferencesDialog.h"
 #include "ui_PreferencesDialog.h"
-#include "MainWindow.h"
 
 class VstPreferencesDialog : public PreferencesDialog
 {
     Q_OBJECT
 
 public:
-    VstPreferencesDialog(MainWindow *mainWindow);
+    VstPreferencesDialog(QWidget *parent);
 
 protected slots:
     void selectTab(int index) override;

--- a/Client/src/resources/jamtaba.css
+++ b/Client/src/resources/jamtaba.css
@@ -12,8 +12,7 @@ PreferencesDialog #buttonAddVstScanFolder{
     background-image: url(:/images/more.png);
     background-position: center center;
     background-repeat: none;
-    height: 32px;
-    margin-right: 24px;
+    margin-right: 12px;
 }
 
 PreferencesDialog #blackListWidget{
@@ -25,6 +24,17 @@ PreferencesDialog #plainTextEdit{
     background: transparent;
 }
 
+PreferencesDialog QGroupBox,
+PreferencesDialog #sampleRateLabel,
+PreferencesDialog #bufferSizeLabel {
+    font-weight: bold;
+}
+
+PreferencesDialog QGroupBox{
+    padding-left: 16px;
+    padding-top: 12px;
+    border: none;
+}
 
 #voteButton{
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -1247,7 +1257,6 @@ NinjamPanel #panelCombos QComboBox::down-arrow:hover
 NinjamPanel #panelCombos QComboBox::drop-down {
     border: 0px;
 }
-
 
 NinjamPanel #metronomeControls, NinjamPanel #panelCombos{
     background: transparent;

--- a/Client/src/resources/jamtaba.css
+++ b/Client/src/resources/jamtaba.css
@@ -16,7 +16,7 @@ PreferencesDialog #buttonAddVstScanFolder{
     margin-right: 24px;
 }
 
-PreferencesDialog #BlackBoxText{
+PreferencesDialog #blackListWidget{
     background-color: black;
     color: orange;
 }


### PR DESCRIPTION
- [x] Create signals for the PreferencesDialog dialog changes
- [x] Decoupling PreferencesDialog from MainController
- [x] Decoupling PreferencesDialog from MainWindow
- [x] Create signals for the PreferencesDialogStandalone dialog changes
- [x] Decoupling PreferencesDialogStandalone from MainController
- [x] Decoupling PreferencesDialogStandalone from MainWindow
- [x] Review PreferencesDialog.ui to use child layouts (replace nested QWidgets)