### PR TITLE
Fix server disconnect by special characters

### DIFF
--- a/src/Common/ninjam/ClientMessages.cpp
+++ b/src/Common/ninjam/ClientMessages.cpp
@@ -98,7 +98,7 @@ ClientSetChannel::ClientSetChannel(const QStringList &channels)
     payload = 2;
     channelNames.append(channels);
     for (int i = 0; i < channelNames.size(); i++) {
-        payload += (channelNames[i].size() + 1) + 2 + 1 + 1;//NUL + volume(short) + pan(byte) + flags(byte)
+        payload += (channelNames[i].toUtf8().size() + 1) + 2 + 1 + 1;//NUL + volume(short) + pan(byte) + flags(byte)
     }
 }
 
@@ -109,7 +109,7 @@ ClientSetChannel::ClientSetChannel(const QString &channelNameToRemove)
     payload = 2;
     channelNames.append(channelNameToRemove);
     for (int i = 0; i < channelNames.size(); i++) {
-        payload += (channelNames[i].size() + 1) + 2 + 1 + 1;//NUL + volume(short) + pan(byte) + flags(byte)
+        payload += (channelNames[i].toUtf8().size() + 1) + 2 + 1 + 1;//NUL + volume(short) + pan(byte) + flags(byte)
     }
 }
 


### PR DESCRIPTION
The problem was reported by @jonjamcam at #294

The details was payload size gap in NINJAM protocol message,
payload size was counted QString::size() but real data size was utf-8's size.

this commit will not fix the same issue for userName.
userName in NINJAM protocol is ASCII only.

fix #294