### PR TITLE
Improving the JamRoomPanel layout to avoid horizontal scroll

### DIFF
--- a/src/Common/gui/JamRoomViewPanel.ui
+++ b/src/Common/gui/JamRoomViewPanel.ui
@@ -57,7 +57,7 @@
        <widget class="QLabel" name="labelName">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>0</horstretch>
+          <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -69,31 +69,6 @@
         </property>
         <property name="text">
          <string notr="true">server name</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="labelRoomStatus">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="accessibleName">
-         <string/>
-        </property>
-        <property name="accessibleDescription">
-         <string>This is the status of this room</string>
-        </property>
-        <property name="frameShape">
-         <enum>QFrame::NoFrame</enum>
-        </property>
-        <property name="text">
-         <string notr="true">5/7 musicians  120 BPM  16 BPI</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -148,28 +123,28 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
-       <number>12</number>
+       <number>6</number>
       </property>
       <property name="topMargin">
-       <number>3</number>
+       <number>6</number>
       </property>
       <property name="rightMargin">
-       <number>12</number>
+       <number>6</number>
       </property>
       <property name="bottomMargin">
-       <number>0</number>
+       <number>6</number>
       </property>
       <item>
        <widget class="QWidget" name="usersPanel" native="true">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+         <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
         <property name="minimumSize">
          <size>
-          <width>150</width>
+          <width>100</width>
           <height>0</height>
          </size>
         </property>
@@ -179,30 +154,72 @@
         <property name="accessibleDescription">
          <string>That panel shows the musicians actually in that room</string>
         </property>
-        <layout class="QVBoxLayout" name="verticalLayout_2"/>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+        </layout>
        </widget>
       </item>
       <item>
-       <widget class="WavePeakPanel" name="wavePeakPanel" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-          <horstretch>1</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="accessibleName">
-         <string/>
-        </property>
-        <property name="accessibleDescription">
-         <string>That zone displays the waveform actually played</string>
-        </property>
-       </widget>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="WavePeakPanel" name="wavePeakPanel" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>15</height>
+           </size>
+          </property>
+          <property name="accessibleName">
+           <string/>
+          </property>
+          <property name="accessibleDescription">
+           <string>That zone displays the waveform actually played</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="labelRoomStatus">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="accessibleName">
+           <string/>
+          </property>
+          <property name="accessibleDescription">
+           <string>This is the status of this room</string>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="text">
+           <string notr="true">5/7 musicians  120 BPM  16 BPI</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>

--- a/src/resources/jamtaba.css
+++ b/src/resources/jamtaba.css
@@ -862,9 +862,9 @@ JamRoomViewPanel #labelName{
     font-weight: bold;
 }
 
-JamRoomViewPanel  #labelRoomStatus, JamRoomViewPanel  #labelRoomType{
+JamRoomViewPanel #labelRoomStatus, JamRoomViewPanel  #labelRoomType{
     font-size: 9px;
-    color: rgb(90, 90, 90);
+    color: rgb(140, 140, 140);
 }
 JamRoomViewPanel  #labelRoomType{
     margin-right: 3px;


### PR DESCRIPTION
The AndyMc servers are using big names and using a lot of horizontal space in the screen. I'm changing the layout to avoid horizontal scroll in the public rooms window.

**Before the changes:**
![image](https://cloud.githubusercontent.com/assets/1012741/14407444/a8a10cce-fe9f-11e5-8a28-45cfac0dac5d.png)

**after the changes (no more horizontal scroll)**
![image](https://cloud.githubusercontent.com/assets/1012741/14407443/911d7c0e-fe9f-11e5-9c5b-df874ba710aa.png)

