### PR TITLE
Fixing the bug when opening in fullscreen

### DIFF
--- a/src/Common/gui/MainWindow.h
+++ b/src/Common/gui/MainWindow.h
@@ -34,7 +34,7 @@ public:
     MainWindow(Controller::MainController *mainController, QWidget *parent = 0);
     virtual ~MainWindow();
 
-    virtual void initialize(); // this is overrided in inherited classes
+    void initialize();
 
     void detachMainController();
 
@@ -214,7 +214,8 @@ private slots:
 
     void updateUserName();
 
-    void doWindowInitialization();
+protected slots:
+        virtual void doWindowInitialization();
 
 private:
 

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -53,9 +53,9 @@ void MainWindowStandalone::setupSignals()
             SLOT(setCurrentScanningPlugin(QString)));
 }
 
-void MainWindowStandalone::initialize()
+void MainWindowStandalone::doWindowInitialization()
 {
-    MainWindow::initialize();
+    MainWindow::doWindowInitialization();
 
     Persistence::Settings settings = mainController->getSettings();
     if (settings.windowsWasFullScreenViewMode()) {

--- a/src/Standalone/gui/MainWindowStandalone.h
+++ b/src/Standalone/gui/MainWindowStandalone.h
@@ -21,8 +21,6 @@ public:
 
     void refreshTrackInputSelection(int inputTrackIndex);
 
-    void initialize() override;
-
     MainControllerStandalone * getMainController() override
     {
         return controller;
@@ -53,6 +51,8 @@ protected slots: //TODO change to private slots?
     void addFoundedPlugin(const QString &name, const QString &group, const QString &path);
     void setCurrentScanningPlugin(const QString &pluginPath);
     void addPluginToBlackList(const QString &pluginPath);
+
+    void doWindowInitialization() override;
 
 private slots:
     void toggleFullScreen();


### PR DESCRIPTION
 - The issue #276 report a bug related with fullscreen. While testing this bug I see another related bug: when close Jamtaba using full screen and reopen the fullscreen is cropped in a very buggy way.

  **The bug context is**: In MainWindow::initialize() the QTimer::singleShot trick is used to avoid freeze the gui when loading many vst plugins in initialization. Using the QTimer::singleShot the GUI is opened, and after 1 milisecond the plugins are loaded (gui is opened when plugins are loading). Without this trick with QTimer::singleShot the **GUI is not opened until the last plugin is loaded**.

 - **The real problem is**: run the window initialization using QTimer::singleShot was spliting the window initialization in two separated calls, and this calls was out of sync.

- **The solution**: now the MainWindow::initialize() is calling doWindowInitialization() using QTimer::singleSlot. The doWindowInitialization() functions  **virtual** and is overrided in MainWindowStandalone (inheriting from MainWindow). **Now the entire window initialization is done inside doWindowInitialization()**, and **no more** problems with **out of sync** function calls.