### PR TITLE
Fix big server name layout issues

### DIFF
--- a/src/Common/gui/ChatMessagePanel.cpp
+++ b/src/Common/gui/ChatMessagePanel.cpp
@@ -54,7 +54,8 @@ void ChatMessagePanel::initialize(const QString &userName, const QString &msg,
     newMessage = replaceLinksInString(newMessage);
     ui->labelMessage->setText(newMessage);
     ui->labelTimeStamp->setText(QTime::currentTime().toString("hh:mm:ss"));
-    ui->labelMessage->setStyleSheet(buildCssString(msgBackgroundColor, textColor));
+
+    ui->messageContent->setStyleSheet(buildCssString(msgBackgroundColor, textColor));
 
     if (showTranslationButton)
         ui->translateButton->setStyleSheet(buildCssString(userNameBackgroundColor, textColor));

--- a/src/Common/gui/ChatMessagePanel.cpp
+++ b/src/Common/gui/ChatMessagePanel.cpp
@@ -41,7 +41,7 @@ void ChatMessagePanel::initialize(const QString &userName, const QString &msg,
                                   bool showTranslationButton)
 {
     if (!userName.isEmpty() && !userName.isNull()) {
-        ui->labelUserName->setText(userName);
+        ui->labelUserName->setText(userName + ":");
         ui->labelUserName->setStyleSheet(buildCssString(userNameBackgroundColor, textColor));
     } else {
         ui->labelUserName->setVisible(false);

--- a/src/Common/gui/ChatMessagePanel.cpp
+++ b/src/Common/gui/ChatMessagePanel.cpp
@@ -6,6 +6,7 @@
 #include <QNetworkRequest>
 #include <QMetaMethod>
 #include "log/Logging.h"
+#include <QTime>
 
 ChatMessagePanel::ChatMessagePanel(QWidget *parent) :
     QWidget(parent),
@@ -52,6 +53,7 @@ void ChatMessagePanel::initialize(const QString &userName, const QString &msg,
     newMessage = newMessage.replace("\n", "<br/>");
     newMessage = replaceLinksInString(newMessage);
     ui->labelMessage->setText(newMessage);
+    ui->labelTimeStamp->setText(QTime::currentTime().toString("hh:mm:ss"));
     ui->labelMessage->setStyleSheet(buildCssString(msgBackgroundColor, textColor));
 
     if (showTranslationButton)

--- a/src/Common/gui/ChatMessagePanel.h
+++ b/src/Common/gui/ChatMessagePanel.h
@@ -25,7 +25,6 @@ signals:
     void startingTranslation();
     void translationFinished();
 
-
 protected:
     void changeEvent(QEvent *) override;
 
@@ -39,6 +38,7 @@ private:
     QString translatedText;
     Ui::ChatMessagePanel *ui;
     QString preferredTargetTranslationLanguage;
+
     static QString replaceLinksInString(const QString &string);
 
     static QString buildCssString(const QColor &bgColor, const QColor &textColor);
@@ -47,6 +47,7 @@ private:
                     const QColor &msgBackgroundColor, const QColor &textColor, bool showTranslationButton);
 
     void setTranslatedMessage(const QString &translatedMessage);
+
 };
 
 #endif // CHATMESSAGEPANEL_H

--- a/src/Common/gui/ChatMessagePanel.ui
+++ b/src/Common/gui/ChatMessagePanel.ui
@@ -123,6 +123,19 @@
      </item>
     </layout>
    </item>
+   <item alignment="Qt::AlignRight">
+    <widget class="QLabel" name="labelTimeStamp">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string notr="true">08:14:53</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/Common/gui/ChatMessagePanel.ui
+++ b/src/Common/gui/ChatMessagePanel.ui
@@ -67,7 +67,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0">
      <property name="spacing">
       <number>0</number>
      </property>
@@ -91,50 +91,77 @@
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="labelMessage">
+      <widget class="QWidget" name="messageContent" native="true">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
          <horstretch>1</horstretch>
          <verstretch>1</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string notr="true">big chat message with many lines to test the behavior</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::RichText</enum>
-       </property>
-       <property name="scaledContents">
-        <bool>false</bool>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-       <property name="textInteractionFlags">
-        <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2" stretch="1,0">
+        <property name="spacing">
+         <number>0</number>
+        </property>
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QLabel" name="labelMessage">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>1</horstretch>
+            <verstretch>1</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string notr="true">big chat message with many lines to test the behavior</string>
+          </property>
+          <property name="textFormat">
+           <enum>Qt::RichText</enum>
+          </property>
+          <property name="scaledContents">
+           <bool>false</bool>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+          <property name="textInteractionFlags">
+           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignRight">
+         <widget class="QLabel" name="labelTimeStamp">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string notr="true">08:14:53</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>
-   </item>
-   <item alignment="Qt::AlignRight">
-    <widget class="QLabel" name="labelTimeStamp">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string notr="true">08:14:53</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/Common/gui/ChatMessagePanel.ui
+++ b/src/Common/gui/ChatMessagePanel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>310</width>
-    <height>125</height>
+    <height>77</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,7 +22,7 @@
   <property name="autoFillBackground">
    <bool>false</bool>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <property name="spacing">
     <number>0</number>
    </property>
@@ -41,90 +41,22 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item alignment="Qt::AlignTop">
-    <widget class="QWidget" name="widget" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>2</verstretch>
-      </sizepolicy>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="labelUserName">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="autoFillBackground">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string notr="true">user name</string>
-        </property>
-        <property name="scaledContents">
-         <bool>false</bool>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-        </property>
-       </widget>
-      </item>
-      <item alignment="Qt::AlignRight|Qt::AlignBottom">
-       <widget class="QPushButton" name="translateButton">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>translate ...</string>
-        </property>
-        <property name="text">
-         <string>T</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
    <item>
-    <widget class="QLabel" name="labelMessage">
+    <widget class="QLabel" name="labelUserName">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="text">
-      <string notr="true">big chat message with many lines to test the behavior</string>
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
      </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
+     <property name="autoFillBackground">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string notr="true">user name</string>
      </property>
      <property name="scaledContents">
       <bool>false</bool>
@@ -132,16 +64,64 @@
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="spacing">
+      <number>0</number>
+     </property>
+     <item alignment="Qt::AlignRight|Qt::AlignBottom">
+      <widget class="QPushButton" name="translateButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>translate ...</string>
+       </property>
+       <property name="text">
+        <string>T</string>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="labelMessage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>1</horstretch>
+         <verstretch>1</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string notr="true">big chat message with many lines to test the behavior</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::RichText</enum>
+       </property>
+       <property name="scaledContents">
+        <bool>false</bool>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+       <property name="textInteractionFlags">
+        <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/Common/gui/ChatPanel.cpp
+++ b/src/Common/gui/ChatPanel.cpp
@@ -150,9 +150,9 @@ void ChatPanel::hideTranslationProgressFeedback()
 void ChatPanel::addMessage(const QString &userName, const QString &userMessage, bool showTranslationButton)
 {
     QColor backgroundColor = getUserColor(userName);
-    QColor textColor = (backgroundColor == BOT_COLOR) ? QColor(50, 50, 50) : QColor(0, 0, 0);
+    bool isBot = backgroundColor == BOT_COLOR;
+    QColor textColor = isBot ? QColor(50, 50, 50) : QColor(0, 0, 0);
     QColor userNameBackgroundColor = backgroundColor;
-
     ChatMessagePanel *msgPanel = new ChatMessagePanel(ui->scrollContent, userName, userMessage,
                                                       userNameBackgroundColor, backgroundColor,
                                                       textColor, showTranslationButton);

--- a/src/Common/gui/ChatPanel.cpp
+++ b/src/Common/gui/ChatPanel.cpp
@@ -149,22 +149,19 @@ void ChatPanel::hideTranslationProgressFeedback()
 
 void ChatPanel::addMessage(const QString &userName, const QString &userMessage, bool showTranslationButton)
 {
-    QColor msgBackgroundColor = getUserColor(userName);
-    QColor textColor = (msgBackgroundColor == BOT_COLOR) ? QColor(50, 50, 50) : QColor(0, 0, 0);
-    QColor userNameBackgroundColor = msgBackgroundColor;
-    if (msgBackgroundColor != BOT_COLOR)
-        userNameBackgroundColor.setHsvF(msgBackgroundColor.hueF(),
-                                        msgBackgroundColor.saturationF(),
-                                        msgBackgroundColor.valueF() - 0.2);
+    QColor backgroundColor = getUserColor(userName);
+    QColor textColor = (backgroundColor == BOT_COLOR) ? QColor(50, 50, 50) : QColor(0, 0, 0);
+    QColor userNameBackgroundColor = backgroundColor;
+
     ChatMessagePanel *msgPanel = new ChatMessagePanel(ui->scrollContent, userName, userMessage,
-                                                      userNameBackgroundColor, msgBackgroundColor,
+                                                      userNameBackgroundColor, backgroundColor,
                                                       textColor, showTranslationButton);
 
     connect(msgPanel, SIGNAL(startingTranslation()), this, SLOT(showTranslationProgressFeedback()));
     connect(msgPanel, SIGNAL(translationFinished()), this, SLOT(hideTranslationProgressFeedback()));
 
     msgPanel->setPrefferedTranslationLanguage(this->autoTranslationLanguage);
-    msgPanel->setMaximumWidth(ui->scrollContent->width());
+    //msgPanel->setMaximumWidth(ui->scrollContent->width());
     ui->scrollContent->layout()->addWidget(msgPanel);
     if (ui->scrollContent->layout()->count() > MAX_MESSAGES) {
         // remove the first widget
@@ -183,8 +180,8 @@ void ChatPanel::addMessage(const QString &userName, const QString &userMessage, 
 // +++++++++++++++++++++++++++++++++++=
 QColor ChatPanel::getUserColor(const QString &userName)
 {
-    if (botNames.contains(userName) || userName.isNull() || userName.isEmpty()
-        || userName == "Jamtaba")
+    if (botNames.contains(userName, Qt::CaseInsensitive) || userName.isEmpty()
+        || userName.toLower() == "jamtaba")
         return BOT_COLOR;
 
     Q_ASSERT(colorsPool);

--- a/src/Common/gui/ChatPanel.h
+++ b/src/Common/gui/ChatPanel.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include <QMap>
+#include <QPushButton>
 #include <QList>
 #include "chords/ChordProgression.h"
 #include "UsersColorsPool.h"

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -645,7 +645,7 @@ void MainWindow::enterInRoom(const Login::RoomInfo &roomInfo)
     qCDebug(jtGUI) << "adding ninjam chat panel...";
     ChatPanel *chatPanel = ninjamWindow->getChatPanel();
     ui.chatTabWidget->addTab(chatPanel, "");
-    updateChatTabTitle(roomInfo.getName());//set and translate the chat tab title
+    updateChatTabTitle();//set and translate the chat tab title
 
     QObject::connect(chatPanel, SIGNAL(userConfirmingChordProgression(
                                            ChordProgression)), this,
@@ -692,10 +692,10 @@ void MainWindow::setUserNameReadOnlyStatus(bool readOnly)
     }
 }
 
-void MainWindow::updateChatTabTitle(const QString &roomName)
+void MainWindow::updateChatTabTitle()
 {
     int chatTabIndex = 0; //assuming chat is the first tab
-    ui.chatTabWidget->setTabText(chatTabIndex, tr("chat %1").arg(roomName));
+    ui.chatTabWidget->setTabText(chatTabIndex, tr("Chat"));
 }
 
 void MainWindow::showMetronomePreferencesDialog()
@@ -843,7 +843,7 @@ void MainWindow::changeEvent(QEvent *ev)
     else if (ev->type() == QEvent::LanguageChange) {
         ui.retranslateUi(this);
         if (ninjamWindow) {
-            updateChatTabTitle(ninjamWindow.data()->getRoomName()); //translate the chat tab title
+            updateChatTabTitle(); //translate the chat tab title
         }
     }
     QMainWindow::changeEvent(ev);

--- a/src/Common/gui/MainWindow.h
+++ b/src/Common/gui/MainWindow.h
@@ -272,7 +272,7 @@ private:
 
     void restoreWindowPosition();
 
-    void updateChatTabTitle(const QString &roomName);
+    void updateChatTabTitle();
 
     void loadTranslationFile(const QString &locale);
 

--- a/src/Common/gui/NinjamRoomWindow.cpp
+++ b/src/Common/gui/NinjamRoomWindow.cpp
@@ -52,9 +52,6 @@ NinjamRoomWindow::NinjamRoomWindow(MainWindow *parent, const Login::RoomInfo &ro
 
     ui->licenceButton->setIcon(QIcon(QPixmap(":/images/licence.png")));
 
-    QString labelText = roomInfo.getName() + " (" + QString::number(roomInfo.getPort()) + ")";
-    ui->labelRoomName->setText(labelText);
-
     ui->tracksPanel->layout()->setAlignment(Qt::AlignLeft);// tracks are left aligned
 
     this->ninjamPanel = createNinjamPanel();
@@ -96,7 +93,7 @@ void NinjamRoomWindow::retranslate()
     verticalLayoutButton->setToolTip(tr("Set tracks layout to vertical"));
     wideButton->setToolTip(tr("Wide tracks"));
     narrowButton->setToolTip(tr("Narrow tracks"));
-    ui->labelUserName->setText(tr("connected as %1").arg(mainController->getUserName()));
+    ui->labelUserName->setText(tr("You are connected as %1").arg(mainController->getUserName()));
 }
 
 void NinjamRoomWindow::createLayoutDirectionButtons(Qt::Orientation initialOrientation)
@@ -551,7 +548,7 @@ void NinjamRoomWindow::showServerLicence()
               .replace("<", "&lt;")
               .replace(brPattern, "<br>")
               .replace(ccLink, anchorTag));
-    msgBox->setWindowTitle(ui->labelRoomName->text());
+    msgBox->setWindowTitle(tr("Server Licence"));
     msgBox->setAttribute(Qt::WA_DeleteOnClose);
 
     // hack to set minimum width in QMessageBox

--- a/src/Common/gui/NinjamRoomWindow.ui
+++ b/src/Common/gui/NinjamRoomWindow.ui
@@ -50,22 +50,6 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QLabel" name="labelRoomName">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="accessibleDescription">
-        <string>This is the room where you are</string>
-       </property>
-       <property name="text">
-        <string notr="true">ninbot.com</string>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QLabel" name="labelUserName">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -74,7 +58,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>(connected as &lt;user_name&gt;)</string>
+        <string>You are connected as &lt;user_name&gt;</string>
        </property>
       </widget>
      </item>

--- a/src/Common/ninjam/Service.cpp
+++ b/src/Common/ninjam/Service.cpp
@@ -184,6 +184,7 @@ QStringList Service::buildBotNamesList()
     names.append("mutantlab.com");
     names.append("LiveStream");
     names.append("localhost");
+    names.append("ninjamers.servebeer.com");
     return names;
 }
 

--- a/src/resources/jamtaba.css
+++ b/src/resources/jamtaba.css
@@ -1388,26 +1388,29 @@ ChatPanel QPushButton#buttonAutoTranslate{
     border: 1px solid #919191;
 }
 
-ChatMessagePanel #labelUserName{
-    padding: 0px;
-    padding-right: 2px;
-    border: 1px solid rgb(0, 0, 0, 40);
-    border-right: none;
+
+ChatMessagePanel #labelUserName,
+ChatMessagePanel #labelMessage
+{
+    border: 1px solid rgb(0, 0, 0, 80);
     border-radius: 2px;
-    border-top-right-radius: 0px;
+}
+
+ChatMessagePanel #labelUserName{
+    border-bottom: none;
     border-bottom-right-radius: 0px;
+
     font-size: 10px;
-    margin-top: 2px;
-    margin-bottom: 2px;
-    margin-right: 0px;
-    margin-left: 0px;
+    font-weight: bold;
 }
 
 ChatMessagePanel #labelMessage{
     padding: 2px;
-    border: 1px solid rgb(0, 0, 0, 80);
-    border-radius: 2px;
-    min-height: 16px;
+    padding-top: 0px;
+
+    border-top-right-radius: 0px;
+    border-top-left-radius: 0px;
+    border-top: none;
 }
 
 ChatMessagePanel #translateButton{

--- a/src/resources/jamtaba.css
+++ b/src/resources/jamtaba.css
@@ -1389,15 +1389,21 @@ ChatPanel QPushButton#buttonAutoTranslate{
 }
 
 ChatMessagePanel #labelUserName,
-ChatMessagePanel #labelMessage
+ChatMessagePanel #messageContent
 {
     border: 1px solid rgb(0, 0, 0, 80);
     border-radius: 2px;
 }
 
+ChatMessagePanel #labelMessage
+{
+    margin: 1px;
+}
+
 ChatMessagePanel #labelTimeStamp{
     font-size: 9px;
     font-style: italic;
+    margin: 2px;
 }
 
 ChatMessagePanel #labelUserName{
@@ -1408,10 +1414,7 @@ ChatMessagePanel #labelUserName{
     font-weight: bold;
 }
 
-ChatMessagePanel #labelMessage{
-    padding: 2px;
-    padding-top: 0px;
-
+ChatMessagePanel #messageContent{
     border-top-right-radius: 0px;
     border-top-left-radius: 0px;
     border-top: none;

--- a/src/resources/jamtaba.css
+++ b/src/resources/jamtaba.css
@@ -1388,12 +1388,16 @@ ChatPanel QPushButton#buttonAutoTranslate{
     border: 1px solid #919191;
 }
 
-
 ChatMessagePanel #labelUserName,
 ChatMessagePanel #labelMessage
 {
     border: 1px solid rgb(0, 0, 0, 80);
     border-radius: 2px;
+}
+
+ChatMessagePanel #labelTimeStamp{
+    font-size: 9px;
+    font-style: italic;
 }
 
 ChatMessagePanel #labelUserName{

--- a/src/resources/jamtaba.css
+++ b/src/resources/jamtaba.css
@@ -1211,11 +1211,6 @@ NinjamRoomWindow #licenceButton:hover{
 
 }
 
-NinjamRoomWindow #labelRoomName{
-    font-size: 11px;
-    font-weight: bold;
-}
-
 NinjamTrackView > #channelName{
     border: none; /* 1px solid rgba(0, 0, 0, 7);*/
     background-color: rgba(0, 0, 0, 6);

--- a/tests/auto/gui/chat/chat.pro
+++ b/tests/auto/gui/chat/chat.pro
@@ -1,0 +1,25 @@
+QT += core gui widgets network
+CONFIG += testcase
+TEMPLATE = app
+TARGET = testChat
+INCLUDEPATH += .
+INCLUDEPATH += ../../../../src/Common
+INCLUDEPATH += ../../../../src/Common/gui
+VPATH += ../../../../src/Common
+
+HEADERS += log/logging.h
+HEADERS += gui/ChatMessagePanel.h
+HEADERS += gui/ChatPanel.h
+HEADERS += gui/UsersColorsPool.h
+
+SOURCES += log/logging.cpp
+SOURCES += gui/ChatMessagePanel.cpp
+SOURCES += gui/ChatPanel.cpp
+SOURCES += gui/UsersColorsPool.cpp
+
+SOURCES += test_Chat.cpp
+
+FORMS += gui/ChatMessagePanel.ui
+FORMS += gui/ChatPanel.ui
+
+RESOURCES += resources.qrc

--- a/tests/auto/gui/chat/resources.qrc
+++ b/tests/auto/gui/chat/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/">
+        <file alias="jamtaba.css">../../../../src/resources/jamtaba.css</file>
+    </qresource>
+</RCC>

--- a/tests/auto/gui/chat/test_Chat.cpp
+++ b/tests/auto/gui/chat/test_Chat.cpp
@@ -14,7 +14,7 @@ int main(int argc, char *argv[])
         app.setStyleSheet(styleSheet.readAll());
 
     UsersColorsPool colorsPool;
-    QStringList botNames;
+    QStringList botNames("ninjamers.servebeer.com");
 
     ChatPanel chatPanel(botNames, &colorsPool);
 
@@ -22,8 +22,11 @@ int main(int argc, char *argv[])
     chatPanel.addMessage("A_big_user_name_", "message", true);
     chatPanel.addMessage("A_big_user_name_", "A big message text to see if the layout is working ok when users decide chat using long texts :)", true);
     chatPanel.addMessage("Jamtaba", "User XXX leave the room", false);
+    chatPanel.addMessage("ninjamers.servebeer.com", "Welcome!", true);
 
     chatPanel.show();
+    chatPanel.setMinimumHeight(400);
+    chatPanel.setMaximumWidth(180); //forcing the mini mode width
 
     return app.exec();
 }

--- a/tests/auto/gui/chat/test_Chat.cpp
+++ b/tests/auto/gui/chat/test_Chat.cpp
@@ -1,0 +1,29 @@
+#include <QApplication>
+#include "ChatMessagePanel.h"
+#include "ChatPanel.h"
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+
+    QFile styleSheet(":/jamtaba.css");
+    if (styleSheet.open(QIODevice::ReadOnly))
+        app.setStyleSheet(styleSheet.readAll());
+
+    UsersColorsPool colorsPool;
+    QStringList botNames;
+
+    ChatPanel chatPanel(botNames, &colorsPool);
+
+    chatPanel.addMessage("UserName", "message", true);
+    chatPanel.addMessage("A_big_user_name_", "message", true);
+    chatPanel.addMessage("A_big_user_name_", "A big message text to see if the layout is working ok when users decide chat using long texts :)", true);
+    chatPanel.addMessage("Jamtaba", "User XXX leave the room", false);
+
+    chatPanel.show();
+
+    return app.exec();
+}


### PR DESCRIPTION
- [x] Drop server name from ninjam window
- [x] Improve chat messages layout to avoid issues with big user names.
- [x] Improve the text in Chat tab when the server is using a big name.
- [x] Add time stamp in chat messages


this PR solve the problems relatated in #318
