### PR TITLE
Improving midi code to ignore uncommon midi messages

### DIFF
--- a/src/Common/midi/MidiDriver.cpp
+++ b/src/Common/midi/MidiDriver.cpp
@@ -34,7 +34,7 @@ void MidiMessageBuffer::addMessage(const MidiMessage &m)
         messages[messagesCount] = m;
         messagesCount++;
     } else {
-        qCWarning(jtMidi) << "MidiBuffer full, discarding the message!";
+        qWarning() << "MidiBuffer full, discarding the message!";
     }
 }
 

--- a/src/Common/midi/RtMidiDriver.h
+++ b/src/Common/midi/RtMidiDriver.h
@@ -25,6 +25,8 @@ public:
 private:
     QList<RtMidiIn *> midiStreams;
 
+    void consumeMessagesFromStream(RtMidiIn *stream, int deviceIndex, MidiMessageBuffer &outBuffer);
+
 };
 }
 #endif // RTMIDIDRIVER_H


### PR DESCRIPTION
Trying to solve the bug described in #209.

I tested the Kontakt using the KingPin lib and can't reproduce the bug. 

This PR is not fixing the bug. I revised the MIDI code to something more clean and taking some precautions. The uncommon midi messages are grabbed from the midi input stream but are ignored. These uncommon messages will not be sended to VST plugins.