### PR TITLE
Fixing mini mode collapsed state when starting jamtaba

### DIFF
--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -55,8 +55,7 @@ void MainWindowStandalone::setupSignals()
 
 void MainWindowStandalone::doWindowInitialization()
 {
-    // set window mode: mini mode or full view mode
-    setFullViewStatus(mainController->getSettings().windowsWasFullViewMode());
+    MainWindow::doWindowInitialization();
 
     Persistence::Settings settings = mainController->getSettings();
     if (settings.windowsWasFullScreenViewMode()) {
@@ -70,8 +69,6 @@ void MainWindowStandalone::doWindowInitialization()
         }
     }
 
-    //create the local tracks, load plugins, etc.
-    QTimer::singleShot(1, this, SLOT(initializeLocalInputChannels()));
 }
 
 void MainWindowStandalone::restoreWindowPosition()


### PR DESCRIPTION
Just fixing the mini mode initialization. The expected behavior is mini mode starting collapsed.

To get mini mode initializing correct I removed the code to lazzy load the VST plugins. It's a temporary solution until I have more time to work in a better solution.