### PR TITLE
fixing-Transmitting-text

### DIFF
--- a/src/Common/gui/LocalTrackGroupView.cpp
+++ b/src/Common/gui/LocalTrackGroupView.cpp
@@ -47,7 +47,7 @@ void LocalTrackGroupView::updateXmitButtonText()
         xmitButton->setText(tr("X"));
     }
     else{
-        xmitButton->setText(isPreparingToTransmit() ? tr("Preparing") : tr("Transmiting"));
+        xmitButton->setText(isPreparingToTransmit() ? tr("Preparing") : tr("Transmitting"));
     }
 }
 


### PR DESCRIPTION
I'm sorry I didn't figure out this one before :(

![image](https://cloud.githubusercontent.com/assets/15310433/14728842/e47dacc0-080e-11e6-86cd-2895f46286f7.png)

![image](https://cloud.githubusercontent.com/assets/15310433/14728857/0faf691a-080f-11e6-96ce-9ebf1c77d593.png)

This means correct this slot in all locale?