### PR TITLE
Fixing screen initialization problems

### DIFF
--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -14,6 +14,7 @@
 
 #include <QDesktopWidget>
 #include <QDesktopServices>
+#include <QRect>
 #include "MainController.h"
 // #include "performance/PerformanceMonitor.h"
 
@@ -1037,13 +1038,13 @@ QSize MainWindow::getSanitizedMinimumWindowSize(const QSize &prefferedMinimumWin
     //minimum size is less then desktop size the fullScreen is buggy because we are forcing an
     //impossible minimum size (the minimum size is too large). This code is ensuring the minimum
     //window size is a valid window size.
-
     QDesktopWidget desktop;
-    bool fullScreen = isFullScreen() || mainController->getSettings().windowsWasFullScreenViewMode();
-    QRect screenGeometry = fullScreen ? desktop.screenGeometry() : desktop.availableGeometry();
-    static const int MARGIN = 5;
-    int minimumWidth = qMin(prefferedMinimumWindowSize.width(), screenGeometry.width() - screenGeometry.left() - MARGIN) ;
-    int minimumHeight = qMin(prefferedMinimumWindowSize.height(), screenGeometry.height() - screenGeometry.top() - MARGIN);
+
+    QSize screenSize = desktop.availableGeometry().size();
+
+    int topBarHeight = frameGeometry().height() - geometry().height(); //geometry is the 'window client area', frameGeometry contain the window title bar area. http://doc.qt.io/qt-4.8/application-windows.html#window-geometry
+    int minimumWidth = qMin(prefferedMinimumWindowSize.width(), screenSize.width()) ;
+    int minimumHeight = qMin(prefferedMinimumWindowSize.height(), screenSize.height() - topBarHeight) ;
     return QSize(minimumWidth, minimumHeight);
 }
 

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -1042,9 +1042,13 @@ QSize MainWindow::getSanitizedMinimumWindowSize(const QSize &prefferedMinimumWin
 
     QSize screenSize = desktop.availableGeometry().size();
 
-    int topBarHeight = frameGeometry().height() - geometry().height(); //geometry is the 'window client area', frameGeometry contain the window title bar area. http://doc.qt.io/qt-4.8/application-windows.html#window-geometry
+    static int topBarHeight = 0;
+    if (topBarHeight == 0) //when the window is fullscreen the topBarHeight is zero (no title window).
+        topBarHeight = frameGeometry().height() - geometry().height(); //geometry is the 'window client area', frameGeometry contain the window title bar area. http://doc.qt.io/qt-4.8/application-windows.html#window-geometry
+
     int minimumWidth = qMin(prefferedMinimumWindowSize.width(), screenSize.width()) ;
     int minimumHeight = qMin(prefferedMinimumWindowSize.height(), screenSize.height() - topBarHeight) ;
+
     return QSize(minimumWidth, minimumHeight);
 }
 

--- a/src/Common/gui/MainWindow.h
+++ b/src/Common/gui/MainWindow.h
@@ -196,6 +196,8 @@ protected slots:
 
     void initializeLocalInputChannels();
 
+    QSize getSanitizedMinimumWindowSize(const QSize &prefferedMinimumWindowSize) const;
+
 private slots:
 
     void showJamtabaCurrentVersion();

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -61,7 +61,7 @@ void MainWindowStandalone::doWindowInitialization()
     if (settings.windowsWasFullScreenViewMode()) {
         setFullScreenStatus(true);
     } else {// not full screen. Is maximized or normal?
-        if (mainController->getSettings().windowWasMaximized()) {
+        if (settings.windowWasMaximized()) {
             qCDebug(jtGUI)<< "setting window state to maximized";
             showMaximized();
         } else {
@@ -149,6 +149,9 @@ void MainWindowStandalone::setFullScreenStatus(bool fullScreen)
         showNormal();
     mainController->setFullScreenView(fullScreenViewMode);
     ui.actionFullscreenMode->setChecked(fullScreen);
+
+    setFullViewStatus(isRunningInFullViewMode()); //update the window size
+
     updatePublicRoomsListLayout();
 }
 

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -150,6 +150,8 @@ void MainWindowStandalone::setFullScreenStatus(bool fullScreen)
     mainController->setFullScreenView(fullScreenViewMode);
     ui.actionFullscreenMode->setChecked(fullScreen);
 
+    QApplication::processEvents(); //process the window resize pending events before call setFullViewStatus and resize the JTB window
+
     setFullViewStatus(isRunningInFullViewMode()); //update the window size
 
     updatePublicRoomsListLayout();

--- a/src/Standalone/main.cpp
+++ b/src/Standalone/main.cpp
@@ -37,8 +37,9 @@ int main(int argc, char* args[] ){
     }
     MainWindowStandalone mainWindow(&mainController);
     mainController.setMainWindow(&mainWindow);
-    mainWindow.initialize();
+
     mainWindow.show();
+    mainWindow.initialize();
 
     mainController.connectInJamtabaServer();
 

--- a/src/Standalone/main.cpp
+++ b/src/Standalone/main.cpp
@@ -38,8 +38,8 @@ int main(int argc, char* args[] ){
     MainWindowStandalone mainWindow(&mainController);
     mainController.setMainWindow(&mainWindow);
 
-    mainWindow.show();
     mainWindow.initialize();
+    mainWindow.show();
 
     mainController.connectInJamtabaServer();
 


### PR DESCRIPTION
- [x] fix the bug when 1) start in full screen and mini mode; and 2) change to full view.

Fixing #343. If MainWindow::showFullScreen() is called after a setMinimumSize(), and the current
minimum size is less then desktop size the fullScreen is buggy because we are forcing an
impossible minimum size (the minimum size is too large). This code is ensuring the minimum
window size is a valid window size.