### PR TITLE
Allow empty user name reported #345

### DIFF
--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -173,11 +173,7 @@ int MainController::getMaxChannelsForEncodingInTrackGroup(uint trackGroupIndex) 
 // ++++++++++++++++++++
 void MainController::setUserName(const QString &newUserName)
 {
-    if (!newUserName.isEmpty()) {
-        settings.setUserName(newUserName);
-    } else {
-        qCritical() << "empty userNAme";
-    }
+    settings.setUserName(newUserName);
 }
 
 QString MainController::getUserName() const

--- a/src/Common/gui/widgets/UserNameLineEdit.cpp
+++ b/src/Common/gui/widgets/UserNameLineEdit.cpp
@@ -5,7 +5,7 @@
 UserNameLineEdit::UserNameLineEdit(QWidget *parent)
     :QLineEdit(parent)
 {
-    static QString userNamePattern("[a-zA-Z0-9 _-]{1,16}"); //allowing lower and upper case letters, numbers, _ and - symbols, blank space, at least 1 character and max 16 characters.
+    static QString userNamePattern("[a-zA-Z0-9 _-]{0,16}"); //allowing lower and upper case letters, numbers, _ and - symbols, blank space, at least 1 character and max 16 characters.
     QRegularExpressionValidator *validator = new QRegularExpressionValidator(QRegularExpression(userNamePattern), this);
     setValidator(validator);
 
@@ -44,26 +44,6 @@ void UserNameLineEdit::sanitizeBlankSpaces()
 {
     QString currentText = text();
     setText( currentText.replace(" ", "_") );
-}
-
-void UserNameLineEdit::focusInEvent(QFocusEvent *e)
-{
-    lastValidUserName = text();
-    QLineEdit::focusInEvent(e);
-}
-
-void UserNameLineEdit::focusOutEvent(QFocusEvent *e)
-{
-    Q_UNUSED(e)
-
-    //if the user name is invalid use the last valid user name
-    QString currentName = text();
-    int pos;
-    if (validator()->validate(currentName, pos) != QValidator::Acceptable) {
-        setText(lastValidUserName);
-    }
-    lastValidUserName = text();
-    QLineEdit::focusOutEvent(e);
 }
 
 void UserNameLineEdit::resizeEvent(QResizeEvent *e)

--- a/src/Common/gui/widgets/UserNameLineEdit.h
+++ b/src/Common/gui/widgets/UserNameLineEdit.h
@@ -24,7 +24,6 @@ private slots:
     void updateText();
 
 private:
-    QString lastValidUserName;
     QKeyEvent *getModifiedEvent(QKeyEvent *e);
 
     void updateTextAlignment();

--- a/src/Common/gui/widgets/UserNameLineEdit.h
+++ b/src/Common/gui/widgets/UserNameLineEdit.h
@@ -16,8 +16,6 @@ public:
     UserNameLineEdit(QWidget *parent=0);
 
 protected:
-    void focusInEvent(QFocusEvent *e) override;
-    void focusOutEvent(QFocusEvent *e) override;
     void resizeEvent(QResizeEvent *e) override;
     void keyPressEvent(QKeyEvent *e) override;
     void keyReleaseEvent(QKeyEvent *e) override;


### PR DESCRIPTION
- drop UserNameLineEdit focus events
- change regexp allow empty {0,16}
  - {,16}  was not worked as expected with Qt's regex
- MainController::setUserName allow empty name now