### PR TITLE
Changing the gain buttons order horizontal layout

### DIFF
--- a/src/Common/gui/NinjamTrackView.cpp
+++ b/src/Common/gui/NinjamTrackView.cpp
@@ -148,7 +148,7 @@ void NinjamTrackView::setupHorizontalLayout()
     levelSlider->setOrientation(Qt::Horizontal);
     levelSliderLayout->setDirection(QBoxLayout::RightToLeft);
 
-    boostWidgetsLayout->setDirection(QHBoxLayout::LeftToRight);
+    boostWidgetsLayout->setDirection(QHBoxLayout::RightToLeft);
 
     peakMeterLeft->setOrientation(Qt::Horizontal);
     peakMeterLeft->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Maximum));


### PR DESCRIPTION
This changes the gain buttons order in the horizontal layout only from +12 0 -12 to -12 0 +12. Issue https://github.com/elieserdejesus/JamTaba/issues/369