### PR TITLE
Black Theme

### DIFF
--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -43,6 +43,26 @@
     border-color: rgb(40, 40, 40);
 }
 
+#buttonBoostMinus12:hover,
+#buttonBoostPlus12:hover,
+#buttonBoostZero:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
+    color: rgb(80, 80, 80);
+    border-radius: 0px;
+    border-color: rgb(40, 40, 40);
+}
+
+#buttonBoostMinus12:hover:checked,
+#buttonBoostPlus12:hover:checked,
+#buttonBoostZero:hover:checked
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
+    color: rgb(80, 80, 80);
+    border-radius: 0px;
+    border-color: rgb(40, 40, 40)
+}
+
 QPushButton#buttonStereoInversion
 {
     background-repeat: none;

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -74,14 +74,14 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #soloButton:checked
 {
-    background-color: rgb(0, 128, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 128, 20), stop:1 rgb(0, 80, 0));
     color: rgb(140, 140, 140);
 }
 
 #soloButton:hover:checked
 {
-    background-color: rgb(0, 128, 0);
-    color: rgb(250, 250, 250);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0, 80, 0));
+    color: rgb(140, 140, 140);
 }
 
 #soloButton:hover
@@ -92,13 +92,13 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #muteButton:checked
 {
-    background-color: rgb(128, 0, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(128, 20, 20), stop:1 rgb(80, 0, 0));
     color: rgb(140, 140, 140);
 }
 
 #muteButton:hover:checked
 {
-    background-color: rgb(128, 0, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(80, 0, 0));
     color: rgb(250, 250, 250);
 }
 

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -163,9 +163,13 @@ BaseTrackView #panSlider::handle:hover
 {
     background-color: rgb(180, 180, 180);
     border: rgb(200, 200, 200);
-    width: 7px;
 }
 
+BaseTrackView #levelSlider::handle:hover
+{
+    background-color: rgb(180, 180, 180);
+    border: rgb(200, 200, 200);
+}
 
 PeakMeter
 {

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -162,8 +162,8 @@ BaseTrackView[unlighted="true"] #peaksDbLabel
 BaseTrackView
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgb(80, 80, 80),
-        stop:1 rgb(20, 20, 20));
+        stop:0 rgb(70, 70, 70),
+        stop:1 rgb(30, 30, 30));
 
     border: none; /*1px solid rgb(61, 61, 61);*/
     font-size: 8px;
@@ -221,7 +221,7 @@ TrackGroupView #topPanel                                /* topPanel is used to s
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(20, 20, 20),
-    stop:1 rgb(80, 80, 80));
+    stop:1 rgb(70, 70, 70));
 
     border-top-left-radius: 1px;
     border-top-right-radius: 1px;

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -37,10 +37,10 @@
 #buttonBoostPlus12:checked,
 #buttonBoostZero:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(80, 80, 80));
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(100, 100, 100), stop:1 rgb(60, 60, 60));
     color: rgba(0, 0, 0, 160);
     border-radius: 0px;
-    border-color: rgb(40, 40, 40);
+    border-color: rgb(20, 20, 20);
 }
 
 #buttonBoostMinus12:hover,
@@ -57,10 +57,10 @@
 #buttonBoostPlus12:hover:checked,
 #buttonBoostZero:hover:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
-    color: rgb(80, 80, 80);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(80, 80, 80), stop:1 rgb(60, 60, 60));
+    color: rgb(40, 40, 40);
     border-radius: 0px;
-    border-color: rgb(40, 40, 40)
+    border-color: rgb(20, 20, 20)
 }
 
 QPushButton#buttonStereoInversion

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -10,7 +10,7 @@
     font-size: 9px;
     border-color: rgb(20 ,20 ,20);
     padding: 2px;
-    color: rgb(50,50,50);
+
 }
 
 #buttonBoostMinus12,
@@ -19,6 +19,7 @@
 #soloButton,
 #muteButton
 {
+    color: rgb(20, 20, 20);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
 }
 
@@ -37,7 +38,7 @@
 #buttonBoostPlus12:checked,
 #buttonBoostZero:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(100, 100, 100), stop:1 rgb(60, 60, 60));
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(100, 100, 100), stop:1 rgb(80, 80, 80));
     color: rgba(0, 0, 0, 160);
     border-radius: 0px;
     border-color: rgb(20, 20, 20);
@@ -57,7 +58,7 @@
 #buttonBoostPlus12:hover:checked,
 #buttonBoostZero:hover:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(80, 80, 80), stop:1 rgb(60, 60, 60));
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(80, 80, 80));
     color: rgb(40, 40, 40);
     border-radius: 0px;
     border-color: rgb(20, 20, 20)
@@ -84,7 +85,7 @@ QPushButton#buttonStereoInversion:hover
 
  QPushButton#buttonStereoInversion:hover:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(80, 80, 80));
 }
 
 /* button colors when the track is NOT xmiting */

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -189,7 +189,7 @@ TrackGroupView[unlighted="true"] > #topPanel                /* the track group t
 
 BaseTrackView #panSlider::handle
 {
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
     border: 1px outset rgb(30, 30, 30);
 
 }
@@ -197,13 +197,11 @@ BaseTrackView #panSlider::handle
 BaseTrackView #panSlider::handle:hover
 {
     background-color: rgb(180, 180, 180);
-    border: rgb(40, 40, 40);
 }
 
 BaseTrackView #levelSlider::handle:hover
 {
     background-color: rgb(180, 180, 180);
-    border: rgb(40, 40, 40);
 }
 
 PeakMeter

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -82,6 +82,11 @@ QPushButton#buttonStereoInversion:hover
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(80, 80, 80));
 }
 
+ QPushButton#buttonStereoInversion:hover:checked
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
+}
+
 /* button colors when the track is NOT xmiting */
 BaseTrackView[unlighted="true"] #buttonBoostMinus12,
 BaseTrackView[unlighted="true"] #buttonBoostZero,

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -37,7 +37,7 @@
 #buttonBoostPlus12:checked,
 #buttonBoostZero:checked
 {
-    background-color: rgb(120, 120, 120);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(80, 80, 80));
     color: rgba(0, 0, 0, 160);
     border-radius: 0px;
     border-color: rgb(40, 40, 40);
@@ -57,6 +57,11 @@ QPushButton#buttonStereoInversion:hover
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
 }
 
+ QPushButton#buttonStereoInversion:checked
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(80, 80, 80));
+}
+
 /* button colors when the track is NOT xmiting */
 BaseTrackView[unlighted="true"] #buttonBoostMinus12,
 BaseTrackView[unlighted="true"] #buttonBoostZero,
@@ -69,7 +74,7 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
     border: none;
 }
 
-#buttonBoostZero:checked
+#buttonBoostZero:buttonStereoInversion
 {
     border-bottom: none;
     border-top: none;
@@ -92,7 +97,7 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 #soloButton:hover
 {
         background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
-    color: rgb(140, 140, 140);
+    color: rgb(80, 80, 80);
 }
 
 #muteButton:checked
@@ -110,7 +115,7 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 #muteButton:hover
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
-    color: rgb(140, 140, 140);
+    color: rgb(80, 80, 80);
 }
 /* Small Label used to show max peak below peak meters
 -------------------------------------------------------*/

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -227,20 +227,3 @@ TrackGroupView #topPanel                                /* topPanel is used to s
     border-top-left-radius: 1px;
     border-top-right-radius: 1px;
 }
-
-TrackGroupView #groupNameField                          /* the text field used to input channel name */
-{
-    margin-bottom: 0px;
-    margin-top: 0px;
-    font-size: 11px;
-    font-weight: normal;
-    border: rgb(80, 80, 80);
-    background-color: rgb(35, 35, 35);
-}
-
-TrackGroupView[unlighted="true"] #groupNameField        /* channel name text field when not xmiting */
-{
-    color: black;
-    background: rgba(255, 255, 255, 20);
-    border: none;
-}

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -109,14 +109,14 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #soloButton:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 128, 20), stop:1 rgb(0, 80, 0));
-    color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0, 80, 0));
+    color: rgb(180, 180, 180);
 }
 
 #soloButton:hover:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0, 80, 0));
-    color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0,120, 0));
+    color: rgb(180, 180, 180);
 }
 
 #soloButton:hover
@@ -127,14 +127,14 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #muteButton:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(128, 20, 20), stop:1 rgb(80, 0, 0));
-    color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(80, 0, 0));
+    color: rgb(180, 180, 180);
 }
 
 #muteButton:hover:checked
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(80, 0, 0));
-    color: rgb(250, 250, 250);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(120, 0, 0));
+    color: rgb(180, 180, 180);
 }
 
 #muteButton:hover

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -19,7 +19,7 @@
 #soloButton,
 #muteButton
 {
-    background: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
 }
 
 
@@ -49,7 +49,12 @@ QPushButton#buttonStereoInversion
     background-position: center center;
     max-width: 8px;
     max-height: 12px;
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
+}
+
+QPushButton#buttonStereoInversion:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
 }
 
 /* button colors when the track is NOT xmiting */
@@ -86,8 +91,8 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #soloButton:hover
 {
-    background-color: rgb(140, 140, 140);
-    color: rgb(200, 200, 200);
+        background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
+    color: rgb(140, 140, 140);
 }
 
 #muteButton:checked
@@ -104,8 +109,8 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
 
 #muteButton:hover
 {
-    background-color: rgb(140, 140, 140);
-    color: rgb(200, 200, 200);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
+    color: rgb(140, 140, 140);
 }
 /* Small Label used to show max peak below peak meters
 -------------------------------------------------------*/

--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -190,20 +190,20 @@ TrackGroupView[unlighted="true"] > #topPanel                /* the track group t
 BaseTrackView #panSlider::handle
 {
     background-color: rgb(140, 140, 140);
-    border: rgb(150, 150, 150);
-    width: 7px;
+    border: 1px outset rgb(30, 30, 30);
+
 }
 
 BaseTrackView #panSlider::handle:hover
 {
     background-color: rgb(180, 180, 180);
-    border: rgb(200, 200, 200);
+    border: rgb(40, 40, 40);
 }
 
 BaseTrackView #levelSlider::handle:hover
 {
     background-color: rgb(180, 180, 180);
-    border: rgb(200, 200, 200);
+    border: rgb(40, 40, 40);
 }
 
 PeakMeter

--- a/src/resources/css/themes/Black/Chat.css
+++ b/src/resources/css/themes/Black/Chat.css
@@ -10,14 +10,14 @@ scroll area, the text input field, but clear and auto translate buttons).
 ChatPanel #chatText
 {                                           /* text input field used to send chat messages */
     border-color: rgba(0, 0, 0, 80);
-    background-color: rgb(80, 80, 80);
+    background-color: rgb(140, 140, 140);
 }
 
 ChatPanel #chatText:focus                   /* text input field focused */
 {
     color: black;
     border-color: rgba(0, 0, 0, 160);
-    background-color: rgb(140, 140, 140);
+    background-color: rgb(180, 180, 180);
 }
 
 

--- a/src/resources/css/themes/Black/Chords.css
+++ b/src/resources/css/themes/Black/Chords.css
@@ -9,5 +9,5 @@ ChordLabel
 
 ChordLabel[current="true"]
 {
-    background-color: rgba(255,255,255, 220);
+    background-color: rgb(140, 140, 140);
 }

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -111,14 +111,14 @@ PluginScanDialog QGroupBox
 
 BusyDialog
 {
-    border: 1px solid rgba(0, 0, 0, 30);
+    border: 1px solid rgba(20, 20, 20);
     padding: 0px;
     margin: 0px;
     border-radius: 3px;
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
             stop:0 rgb(80, 80, 80),
-            stop:0.1 rgb(60, 60, 60)
-            stop:0.9 rgba(40, 40, 40),
+            stop:0.3 rgb(60, 60, 60)
+            stop:0.6 rgba(40, 40, 40),
             stop:1 rgba(20, 20, 20));
 }
 

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -102,6 +102,11 @@ PluginScanDialog
     stop:1 rgb(40, 40, 40));
 }
 
+PluginScanDialog QGroupBox
+{
+    border: 1px solid black;
+}
+
 BusyDialog
 {
     border: 1px solid rgba(0, 0, 0, 30);

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -18,24 +18,6 @@ PrivateServerDialog
     stop:1 rgb(40, 40, 40));
 }
 
-/*
-PrivateServerDialog #passwordTextField, #serverPortTextField, #serverTextField
-{
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(140, 140, 140);
-}
-
-UserNameDialog #lineEdit
-{
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(140, 140, 140);
-}
-*/
-
 PrivateServerDialog #label, #label_2, #label_3
 {
     color: rgb(160, 160, 160);
@@ -70,16 +52,6 @@ PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop dow
     selection-color: rgb(10, 10, 10);
 }
 
-/*
-PreferencesDialog #recordPathLineEdit, #textFieldPrimaryBeat, #textFieldSecondaryBeat
-{
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(140, 140, 140);
-}
-*/
-
 PreferencesDialog #vstListWidget
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
@@ -87,7 +59,7 @@ PreferencesDialog #vstListWidget
     stop:1 rgb(120, 120, 120));;
 }
 
-MidiToolsDialog #label_5, #labelHigherNote, #labelLowerNoteX
+MidiToolsDialog #label_5, #labelHigherNote, #labelLowerNote
 {
     color: rgb(160, 160, 160);
 }
@@ -100,21 +72,11 @@ MidiToolsDialog #GroupBoxKeyRange, #GroupBoxTranspose
 MidiToolsDialog #spinBoxTranspose
 {
     border: 1px solid rgb(80, 80, 80);
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
+    color: rgb(20, 20, 20);
+    background-color: rgb(110, 110, 110);
     selection-background-color: rgb(50, 50, 50);
     selection-color: rgb(140, 140, 140);
 }
-
-/*
-MidiToolsDialog #textFieldHigherNote, #textFieldLowerNote
-{
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(140, 140, 140);
-}
-*/
 
 QInputDialog QPushButton
 {
@@ -136,7 +98,7 @@ PluginScanDialog #labelPluginText
 PluginScanDialog
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(120, 120, 120),
+    stop:0 rgb(80, 80, 80),
     stop:1 rgb(40, 40, 40));
 }
 

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -98,13 +98,15 @@ PluginScanDialog #labelPluginText
 PluginScanDialog
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(80, 80, 80),
+    stop:0 rgb(90, 90, 90),
     stop:1 rgb(40, 40, 40));
 }
 
 PluginScanDialog QGroupBox
 {
-    border: 1px solid black;
+    color: rgb(180, 180, 180);
+    border: 1px solid gray;
+    selection-color: rgb(140, 140, 140);
 }
 
 BusyDialog

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -3,16 +3,7 @@
 QMessageBox,
 QInputDialog,
 PluginScanDialog,
-MidiToolsDialog
-{
-    color: rgb(140, 140, 140);
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgb(40, 40, 40),
-        stop:1 rgba(20, 20, 20));
-
-    border-radius: 2px;
-}
-
+MidiToolsDialog,
 PreferencesDialog
 {
     border-color: rgb(20, 20, 20);
@@ -23,6 +14,23 @@ PreferencesDialog
 PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome
 {
     background-color: rgb(40, 40, 40);
+}
+
+
+PreferencesDialog QComboBox                         /* the colors inside the combo box*/
+{
+    background-color: rgb(80, 80, 80);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(10, 10, 10);
+}
+
+PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/
+{
+    border: 1px solid black;
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(10, 10, 10);
 }
 
 QInputDialog QPushButton
@@ -68,18 +76,3 @@ BusyDialog > QLabel /* the text appearing in Busy dialog, like "connecting in ni
     color: rgb(140, 140, 140);
 }
 
-PreferencesDialog QComboBox                         /* the colors inside the combo box*/
-{
-    background-color: rgb(80, 80, 80);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(10, 10, 10);
-}
-
-PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/
-{
-    border: 1px solid black;
-    color: rgb(160, 160, 160);
-    background-color: rgb(70, 70, 70);
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(10, 10, 10);
-}

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -1,6 +1,16 @@
 /* Dialogs in Black theme
 -------------------------------------*/
 
+PreferencesDialog
+{
+    background-color: rgb(35, 35, 35);
+}
+
+PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome
+{
+    background-color: rgb(80, 80, 80);
+}
+
 PluginScanDialog
 {
     background-color: rgb(80, 80, 80);

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -4,6 +4,7 @@ QMessageBox,
 QInputDialog,
 PluginScanDialog,
 MidiToolsDialog,
+PluginScanDialog,
 PreferencesDialog
 {
     border-color: rgb(20, 20, 20);
@@ -38,13 +39,6 @@ QInputDialog QPushButton
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgb(20,20,20), stop:0.02 rgb(80, 80, 80), stop:0.7 rgba(90, 90, 90), stop:1 rgb(40,40,40));
     border-color: rgb(20, 20, 20);
     color: rgb(140,140,140);
-}
-
-PluginScanDialog
-{
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgb(250, 250, 250),
-        stop:1 rgb(220, 220, 220));
 }
 
 PluginScanDialog QPlainTextEdit

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -92,6 +92,7 @@ PluginScanDialog QPlainTextEdit
 
 PluginScanDialog #labelPluginText
 {
+    color: rgb(20, 20, 20,);
     font-weight: bold;
 }
 

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -98,7 +98,7 @@ PluginScanDialog #labelPluginText
 PluginScanDialog
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(90, 90, 90),
+    stop:0 rgb(80, 80, 80),
     stop:1 rgb(40, 40, 40));
 }
 

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -7,9 +7,7 @@ PreferencesDialog
 
 QMessageBox,
 QInputDialog,
-PluginScanDialog,
 MidiToolsDialog,
-PluginScanDialog,
 UserNameDialog,
 PrivateServerDialog
 {
@@ -20,12 +18,13 @@ PrivateServerDialog
     stop:1 rgb(40, 40, 40));
 }
 
+/*
 PrivateServerDialog #passwordTextField, #serverPortTextField, #serverTextField
 {
     color: rgb(160, 160, 160);
     background-color: rgb(70, 70, 70);
     selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(40, 40, 40);
+    selection-color: rgb(140, 140, 140);
 }
 
 UserNameDialog #lineEdit
@@ -33,8 +32,9 @@ UserNameDialog #lineEdit
     color: rgb(160, 160, 160);
     background-color: rgb(70, 70, 70);
     selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(40, 40, 40);
+    selection-color: rgb(140, 140, 140);
 }
+*/
 
 PrivateServerDialog #label, #label_2, #label_3
 {
@@ -70,6 +70,23 @@ PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop dow
     selection-color: rgb(10, 10, 10);
 }
 
+/*
+PreferencesDialog #recordPathLineEdit, #textFieldPrimaryBeat, #textFieldSecondaryBeat
+{
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(140, 140, 140);
+}
+*/
+
+PreferencesDialog #vstListWidget
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(180, 180, 180),
+    stop:1 rgb(120, 120, 120));;
+}
+
 MidiToolsDialog #label_5, #labelHigherNote, #labelLowerNoteX
 {
     color: rgb(160, 160, 160);
@@ -82,12 +99,22 @@ MidiToolsDialog #GroupBoxKeyRange, #GroupBoxTranspose
 
 MidiToolsDialog #spinBoxTranspose
 {
-    border: 1px solid rgb(140, 140, 140);
+    border: 1px solid rgb(80, 80, 80);
     color: rgb(160, 160, 160);
     background-color: rgb(70, 70, 70);
     selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(40, 40, 40);
+    selection-color: rgb(140, 140, 140);
 }
+
+/*
+MidiToolsDialog #textFieldHigherNote, #textFieldLowerNote
+{
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(140, 140, 140);
+}
+*/
 
 QInputDialog QPushButton
 {
@@ -104,6 +131,13 @@ PluginScanDialog QPlainTextEdit
 PluginScanDialog #labelPluginText
 {
     font-weight: bold;
+}
+
+PluginScanDialog
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(120, 120, 120),
+    stop:1 rgb(40, 40, 40));
 }
 
 BusyDialog

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -1,21 +1,43 @@
-/* Dialogs in Black theme
--------------------------------------*/
+/* Dialogs in Black theme */
+
+QMessageBox,
+QInputDialog,
+PluginScanDialog,
+MidiToolsDialog
+{
+    color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgb(40, 40, 40),
+        stop:1 rgba(20, 20, 20));
+
+    border-radius: 2px;
+}
 
 PreferencesDialog
 {
-    background-color: rgb(35, 35, 35);
+    border-color: rgb(20, 20, 20);
+    color: rgb(40, 40, 40);
+    background-color: rgb(80, 80, 80);
 }
 
 PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome
 {
-    background-color: rgb(80, 80, 80);
+    background-color: rgb(40, 40, 40);
+}
+
+QInputDialog QPushButton
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgb(20,20,20), stop:0.02 rgb(80, 80, 80), stop:0.7 rgba(90, 90, 90), stop:1 rgb(40,40,40));
+    border-color: rgb(20, 20, 20);
+    color: rgb(140,140,140);
 }
 
 PluginScanDialog
 {
-    background-color: rgb(80, 80, 80);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgb(250, 250, 250),
+        stop:1 rgb(220, 220, 220));
 }
-
 
 PluginScanDialog QPlainTextEdit
 {
@@ -29,20 +51,35 @@ PluginScanDialog #labelPluginText
 
 BusyDialog
 {
-    border: 1px solid rgb(40, 40, 40);
+    border: 1px solid rgba(0, 0, 0, 30);
     padding: 0px;
     margin: 0px;
+    border-radius: 3px;
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(80, 80, 80),
-    stop:1 rgb(20, 20, 20));
+            stop:0 rgb(80, 80, 80),
+            stop:0.1 rgb(60, 60, 60)
+            stop:0.9 rgba(40, 40, 40),
+            stop:1 rgba(20, 20, 20));
 }
 
-QMessageBox,
-QInputDialog,
-PluginScanDialog,
-MidiToolsDialog
+BusyDialog > QLabel /* the text appearing in Busy dialog, like "connecting in ninbot.com" */
 {
-    background-color: rgb(140, 140, 140);
-    border: 1px outset gray;
-    padding: 32px;
+    font-weight: bold;
+    color: rgb(140, 140, 140);
+}
+
+PreferencesDialog QComboBox                         /* the colors inside the combo box*/
+{
+    background-color: rgb(80, 80, 80);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(10, 10, 10);
+}
+
+PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/
+{
+    border: 1px solid black;
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(10, 10, 10);
 }

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -1,24 +1,58 @@
 /* Dialogs in Black theme */
 
+PreferencesDialog
+{
+    background-color: rgb(70, 70, 70);
+}
+
 QMessageBox,
 QInputDialog,
 PluginScanDialog,
 MidiToolsDialog,
 PluginScanDialog,
-PrivateServerDialog,
 UserNameDialog,
-PreferencesDialog
+PrivateServerDialog
 {
     border-color: rgb(20, 20, 20);
     color: rgb(40, 40, 40);
-    background-color: rgb(80, 80, 80);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(70, 70, 70),
+    stop:1 rgb(40, 40, 40));
+}
+
+PrivateServerDialog #passwordTextField, #serverPortTextField, #serverTextField
+{
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(40, 40, 40);
+}
+
+UserNameDialog #lineEdit
+{
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(40, 40, 40);
+}
+
+PrivateServerDialog #label, #label_2, #label_3
+{
+    color: rgb(160, 160, 160);
+}
+
+UserNameDialog #label
+{
+    color: rgb(160, 160, 160);
 }
 
 PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome
 {
-    background-color: rgb(40, 40, 40);
+    border: 1px solid rgb(40, 40, 40);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(70, 70, 70),
+    stop:1 rgb(40, 40, 40));
 }
-
 
 PreferencesDialog QComboBox                         /* the colors inside the combo box*/
 {
@@ -34,6 +68,25 @@ PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop dow
     background-color: rgb(70, 70, 70);
     selection-background-color: rgb(50, 50, 50);
     selection-color: rgb(10, 10, 10);
+}
+
+MidiToolsDialog #label_5, #labelHigherNote, #labelLowerNoteX
+{
+    color: rgb(160, 160, 160);
+}
+
+MidiToolsDialog #GroupBoxKeyRange, #GroupBoxTranspose
+{
+    color: rgb(160, 160, 160);
+}
+
+MidiToolsDialog #spinBoxTranspose
+{
+    border: 1px solid rgb(140, 140, 140);
+    color: rgb(160, 160, 160);
+    background-color: rgb(70, 70, 70);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(40, 40, 40);
 }
 
 QInputDialog QPushButton

--- a/src/resources/css/themes/Black/Dialogs.css
+++ b/src/resources/css/themes/Black/Dialogs.css
@@ -5,6 +5,8 @@ QInputDialog,
 PluginScanDialog,
 MidiToolsDialog,
 PluginScanDialog,
+PrivateServerDialog,
+UserNameDialog,
 PreferencesDialog
 {
     border-color: rgb(20, 20, 20);

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -133,7 +133,7 @@ QLineEdit
 {
     background-color: rgb(100, 100, 100);
     border-color: rgba(0, 0, 0, 45);
-    color: rgb(40, 40, 40);
+    color: rgb(60, 60, 60);
 }
 
 QLineEdit:focus
@@ -252,4 +252,9 @@ QMenu
     border: 1px outset rgb(20, 20, 20);
     color: rgb(140, 140, 140);
     background:rgb(35, 35, 35);
+}
+
+QTabWidget::pane
+{
+    background-color: transparent;
 }

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -131,20 +131,25 @@ QScrollBar::sub-page:horizontal
 -----------------------------------------------------------------------*/
 QLineEdit
 {
-    background-color: rgb(140, 140, 140);
+    background-color: rgb(100, 100, 100);
     border-color: rgba(0, 0, 0, 45);
-    color: rgb(80, 80, 80);
+    color: rgb(40, 40, 40);
 }
 
-QLineEdit:focus,
-QLineEdit#groupNameField:focus
+QLineEdit:focus
 {
-    border-color: rgba(0, 0, 0, 90);
-    background-color: rgb(35, 35, 35);
+    background-color: rgb(80, 80, 80);
     color: rgb(180, 180, 180);
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(140, 140, 140);
 }
 
-
+QLineEdit#groupNameField:focus, #userNameLineEdit:focus
+{
+    color: rgb(200, 200, 200);
+    selection-background-color: rgb(120, 120, 120);
+    selection-color: rgb(80, 80, 80);
+}
 
 /*  SLIDERs ++++++++++++++++++++++++++++++++ */
 

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -59,18 +59,48 @@ QScrollBar:horizontal
     margin-top: 6px;
 }
 
-QScrollBar::handle:vertical,
 QScrollBar::handle:horizontal
 {
-  border: 1px solid rgba(0, 0, 0, 45);
-  background-color: rgb(80, 80, 80);
-  margin: 0px;
+    background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0,
+        stop:0 rgba(120, 126, 118, 80),
+        stop:0.47 rgba(91, 91, 91, 80),
+        stop:0.49 rgba(81, 75, 77, 80),
+        stop:0.92 rgba(142, 140, 140, 80));
+
+    max-height: 20px;
+    height: 20px;
 }
 
-QScrollBar::handle:horizontal:hover,
+QScrollBar::handle:horizontal:hover
+{
+    background-color: qlineargradient(spread:pad, x1:0, y1:1, x2:0, y2:0,
+        stop:0 rgba(140, 146, 138, 200),
+        stop:0.47 rgba(121, 121, 121, 200),
+        stop:0.49 rgba(111, 95, 97, 200),
+        stop:0.92 rgba(172, 170, 170, 200)
+    );
+}
+
+
+QScrollBar::handle:vertical
+{
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0,
+        stop:0.92 rgba(120, 126, 118, 80),
+        stop:0.49 rgba(91, 91, 91, 80),
+        stop:0.47 rgba(81, 75, 77, 80),
+        stop:0 rgba(142, 140, 140, 80));
+
+    max-width: 20px;
+    width: 20px;
+}
+
 QScrollBar::handle:vertical:hover
 {
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(spread:pad, x1:0, y1:0, x2:1, y2:0,
+        stop:0.92 rgba(140, 146, 138, 200),
+        stop:0.49 rgba(121, 121, 121, 200),
+        stop:0.47 rgba(111, 95, 97, 200),
+        stop:0 rgba(172, 170, 170, 200));
 }
 
 QScrollBar::handle:vertical

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -6,7 +6,7 @@ QPushButton
 {
     color: rgb(40, 40, 40);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
-    border: 1px outset rgb(30, 30, 30);
+    border: 1px outset rgb(20, 20, 20);
     border: 1px solid black;
 }
 
@@ -21,7 +21,7 @@ QPushButton:hover
 {
     color: rgb(40, 40, 40);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
-    border: 1px outset rgb(30, 30, 30);
+    border: 1px outset rgb(20, 20, 20);
 }
 
 QPushButton:hover:checked
@@ -31,11 +31,11 @@ QPushButton:hover:checked
     border: 1px outset rgb(10, 10, 10);
 }
 
-QPushButton[enabled="false"]        /* disabled buttons */
+QPushButton[enabled="false"]
 {
-    background: none;
-    color: black;
-    border-color: rgba(0, 0, 0, 40);
+    background-color: rgba(0, 0, 0, 40);
+    color: rgba(0, 0, 0, 100);
+    border-color: rgba(0, 0, 0, 20);
 }
 
 /* Scroll bars ----------------------*/

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -4,21 +4,31 @@
 /* Button ----------------------*/
 QPushButton
 {
-    color: rgb(20, 20, 20);
-    background-color: rgb(140, 140, 140);
+    color: rgb(40, 40, 40);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
+    border: 1px outset rgb(30, 30, 30);
     border: 1px solid black;
 }
 
 QPushButton:checked
 {
-    background-color: rgb(80, 80, 80);
-    color: rgb(140, 140, 140);
+    color: rgb(180, 180, 180);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(60, 60, 60));
+    border: 1px outset rgb(10, 10, 10);
 }
 
 QPushButton:hover
 {
+    color: rgb(40, 40, 40);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
+    border: 1px outset rgb(30, 30, 30);
+}
+
+QPushButton:hover:checked
+{
     color: rgb(180, 180, 180);
-    border: 1px solid black;
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(80, 80, 80));
+    border: 1px outset rgb(10, 10, 10);
 }
 
 QPushButton[enabled="false"]        /* disabled buttons */
@@ -197,18 +207,24 @@ QTabBar::tab
     background-color: rgb(200, 200, 200);
 }
 
-QTabBar::tab:selected,
-QTabBar::tab:hover
+QTabBar::tab:selected
 {
     color: rgb(140, 140,140);
-    background-color: rgb(20, 20, 20)
+    background-color: rgb(20, 20, 20);
+}
+
+QTabBar::tab:hover,
+QTabBar::tab:hover:checked
+{
+    color: rgb(140, 140,140);
+    background-color: rgb(30, 30, 30);
 }
 
 QTabBar::tab:!selected
 {
     margin-top: 3px; /* make non-selected tabs look smaller */
     color: rgb(140, 140,140);
-    background-color: black
+    background-color: rgb(10, 10, 10);
 }
 
 QMenuBar::item

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -210,3 +210,21 @@ QTabBar::tab:!selected
     color: rgb(140, 140,140);
     background-color: black
 }
+
+QMenuBar::item
+{
+    color: rgb(140, 140, 140);
+    background:rgb(35, 35, 35);
+}
+
+QMenuBar
+{
+    background:rgb(35, 35, 35);
+}
+
+QMenu
+{
+    border: 1px outset rgb(10, 10, 10);
+    color: rgb(140, 140, 140);
+    background:rgb(35, 35, 35);
+}

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -4,7 +4,7 @@
 /* Button ----------------------*/
 QPushButton
 {
-    color: rgb(40, 40, 40);
+    color: rgb(20, 20, 20);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
     border: 1px outset rgb(20, 20, 20);
     border: 1px solid black;

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -158,7 +158,7 @@ QSlider::groove:vertical
 QSlider::handle:horizontal
 {
     background: rgb(80, 80, 80);
-    border: 1px outset rgb(80, 80, 80);
+    border: 1px outset rgb(10, 10, 10);
     border-radius: 2px;
     margin-top: -8px;
     margin-bottom: -7px;
@@ -169,8 +169,8 @@ QSlider::handle:horizontal
 
 QSlider::handle:vertical
 {
-    background: rgb(125, 125, 125);
-    border: 1px outset rgb(100, 100, 100);
+    background: rgb(140, 140, 140);
+    border: 1px outset rgb(30, 30, 30);
     border-radius: 2px;
     margin-left: -9px;
     margin-right: -9px;

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -141,7 +141,7 @@ QLineEdit#groupNameField:focus
 {
     border-color: rgba(0, 0, 0, 90);
     background-color: rgb(35, 35, 35);
-    color: rgb(80, 80, 80);
+    color: rgb(180, 180, 180);
 }
 
 

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -12,7 +12,7 @@ QPushButton
 
 QPushButton:checked
 {
-    color: rgb(180, 180, 180);
+    color: rgba(0, 0, 0, 160);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(60, 60, 60));
     border: 1px outset rgb(10, 10, 10);
 }
@@ -26,7 +26,7 @@ QPushButton:hover
 
 QPushButton:hover:checked
 {
-    color: rgb(180, 180, 180);
+    color: rgba(0, 0, 0, 160);
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(80, 80, 80));
     border: 1px outset rgb(10, 10, 10);
 }

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -157,7 +157,7 @@ QSlider::groove:vertical
 
 QSlider::handle:horizontal
 {
-    background: rgb(80, 80, 80);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(120, 120, 120), stop:1 rgb(60, 60, 60));
     border: 1px outset rgb(10, 10, 10);
     border-radius: 2px;
     margin-top: -8px;
@@ -169,7 +169,7 @@ QSlider::handle:horizontal
 
 QSlider::handle:vertical
 {
-    background: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
     border: 1px outset rgb(30, 30, 30);
     border-radius: 2px;
     margin-left: -9px;
@@ -181,14 +181,12 @@ QSlider::handle:vertical
 
 QSlider::handle:horizontal:hover
 {
-    background: rgb(150, 150, 150);
-    border: 1px outset rgb(80, 80, 80);
+    background-color: rgb(140, 140, 140);
 }
 
 QSlider::handle:vertical:hover
 {
-    background: rgb(180, 180, 180);
-    border: 1px outset rgb(80, 80, 80);
+    background-color: rgb(140, 140, 140);
 }
 
 

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -230,12 +230,12 @@ QTabBar::tab:!selected
 QMenuBar::item
 {
     color: rgb(140, 140, 140);
-    background:rgb(35, 35, 35);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(50, 50, 50), stop:1 rgb(30, 30, 30));
 }
 
 QMenuBar
 {
-    background:rgb(35, 35, 35);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(50, 50, 50), stop:1 rgb(30, 30, 30));
     border-bottom: none;
     border-top: 1px solid rgb(100, 100, 100);
     border-left: 1px solid rgb(100, 100, 100);
@@ -244,7 +244,7 @@ QMenuBar
 
 QMenu
 {
-    border: 1px outset rgb(10, 10, 10);
+    border: 1px outset rgb(20, 20, 20);
     color: rgb(140, 140, 140);
     background:rgb(35, 35, 35);
 }

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -236,6 +236,10 @@ QMenuBar::item
 QMenuBar
 {
     background:rgb(35, 35, 35);
+    border-bottom: none;
+    border-top: 1px solid rgb(100, 100, 100);
+    border-left: 1px solid rgb(100, 100, 100);
+    border-right: 1px solid rgb(100, 100, 100);
 }
 
 QMenu

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -174,13 +174,17 @@ background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20,
 LocalTrackGroupView #groupNameField
 {
     color: rgb(140, 140, 140);
-    background-color: rgb(50, 50, 50);
-    border-color: rgb(50, 50, 50);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(50, 50, 50),
+    stop:1 rgb(65, 65, 65));
+    border: 1px solid rgb(54, 54, 54);
 }
 
 LocalTrackGroupView #groupNameField:focus
 {
     color: rgb(180, 180, 180);
-    background-color: rgb(50, 50, 50);
-    border-color: rgb(30, 30, 30);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(55, 55, 55),
+    stop:1 rgb(65, 65, 65));
+    border: 1px solid rgb(60, 60, 60);
 }

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -175,12 +175,12 @@ LocalTrackGroupView #groupNameField
 {
     color: rgb(140, 140, 140);
     background-color: rgb(50, 50, 50);
-    border-color: rgb(20, 20, 20);
+    border-color: rgb(50, 50, 50);
 }
 
 LocalTrackGroupView #groupNameField:focus
 {
-    color: rgb(140, 140, 140);
+    color: rgb(180, 180, 180);
     background-color: rgb(50, 50, 50);
-    border-color: rgb(20, 20, 20);
+    border-color: rgb(30, 30, 30);
 }

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -36,6 +36,11 @@ FxPanelItem QLabel                                     /* plugin name label */
     margin: 0px;
 }
 
+FxPanelItem QLabel:hover
+{
+    color: rgb(180, 180, 180);
+}
+
 FxPanelItem:hover                                       /* slot hover effect */
 {
     background-color: rgba(0, 0, 0, 60);

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -182,7 +182,7 @@ LocalTrackGroupView #groupNameField
 
 LocalTrackGroupView #groupNameField:focus
 {
-    color: rgb(180, 180, 180);
+    color: rgb(140, 140, 140);
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(55, 55, 55),
     stop:1 rgb(65, 65, 65));

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -179,12 +179,3 @@ LocalTrackGroupView #groupNameField
     stop:1 rgb(65, 65, 65));
     border: 1px solid rgb(54, 54, 54);
 }
-
-LocalTrackGroupView #groupNameField:focus
-{
-    color: rgb(150, 150, 150);
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(50, 50, 50),
-    stop:1 rgb(65, 65, 65));
-    border: 1px solid rgb(54, 54, 54);
-}

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -170,3 +170,17 @@ background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180,
 background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(80, 0, 0));
     border-color: rgba(0, 0, 0, 90);
 }
+
+LocalTrackGroupView #groupNameField
+{
+    color: rgb(140, 140, 140);
+    background-color: rgb(50, 50, 50);
+    border-color: rgb(20, 20, 20);
+}
+
+LocalTrackGroupView #groupNameField:focus
+{
+    color: rgb(140, 140, 140);
+    background-color: rgb(50, 50, 50);
+    border-color: rgb(20, 20, 20);
+}

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -123,7 +123,7 @@ LocalTrackView #midiToolsButton                 /* The button used to open MidiT
 {
     color: rgb(20, 20, 20);
     border: 1px outset rgb(40, 40, 40);
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(140, 140, 140), stop:1 rgb(120, 120, 120));
     font-size: 10px;
     background-repeat: none;
     background-position: center left;
@@ -132,7 +132,7 @@ LocalTrackView #midiToolsButton                 /* The button used to open MidiT
 
 LocalTrackView #midiToolsButton:hover                 /* The button used to open MidiToolsDialog */
 {
-   background-color: rgb(180, 180, 180);
+       background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
 }
 
 

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -174,8 +174,10 @@ background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20,
 LocalTrackGroupView #groupNameField
 {
     color: rgb(150, 150, 150);
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(50, 50, 50),
-    stop:1 rgb(65, 65, 65));
-    border: 1px solid rgb(54, 54, 54);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+            stop:0 rgb(85, 85, 85),
+            stop:0.1 rgb(65, 65, 65)
+            stop:0.9 rgba(45, 45, 45),
+            stop:1 rgba(25, 25, 25));
+    border: 1px solid rgb(55, 55, 55);
 }

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -64,13 +64,13 @@ FxPanelItem QPushButton:hover                           /* hover effect for the 
 
 FxPanelItem QPushButton:checked                         /* 'plugin bypass' button is checked */
 {
-    background-color: rgb(0, 128, 0);
-    border-color: rgb(0, 100, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 128, 20), stop:1 rgb(0, 80, 0));
+    border-color: rgb(20, 20, 20);
 }
 
 FxPanelItem QPushButton:checked:hover                   /* hover effect for 'plugin bypass' button when checked */
 {
-    background-color: rgb(0, 180, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0, 80, 0));
 }
 
 

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -150,7 +150,7 @@ LocalTrackView #midiToolsButton:hover                 /* The button used to open
 
 #xmitButton[preparing="true"]
 {
-background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(128, 128, 20), stop:1 rgb(80, 80, 0));
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 20), stop:1 rgb(80, 80, 0));
 }
 
 #xmitButton:!checked

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -143,30 +143,30 @@ LocalTrackView #midiToolsButton:hover                 /* The button used to open
 
 #xmitButton:checked
 {
-    background-color: rgb(0, 128, 0);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 128, 20), stop:1 rgb(0, 80, 0));
     border-color: rgb(20, 20, 20);
     color: rgb(20, 20, 20);
 }
 
 #xmitButton[preparing="true"]
 {
-    background-color: rgb(128, 128, 0);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(128, 128, 20), stop:1 rgb(80, 80, 0));
 }
 
 #xmitButton:!checked
 {
-    background-color: rgb(128, 0, 0);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(128, 20, 20), stop:1 rgb(80, 0, 0));
     border-color: rgb(128, 0, 0);
     color: rgb(140, 140, 140);
 }
 
 #xmitButton:hover
 {
-    background-color: rgb(0, 180, 0);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(20, 180, 20), stop:1 rgb(0, 80, 0));
 }
 
 #xmitButton:hover:!checked
 {
-    background-color: rgb(180, 0, 0);
+background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20, 20), stop:1 rgb(80, 0, 0));
     border-color: rgba(0, 0, 0, 90);
 }

--- a/src/resources/css/themes/Black/LocalTrack.css
+++ b/src/resources/css/themes/Black/LocalTrack.css
@@ -173,7 +173,7 @@ background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 20,
 
 LocalTrackGroupView #groupNameField
 {
-    color: rgb(140, 140, 140);
+    color: rgb(150, 150, 150);
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(50, 50, 50),
     stop:1 rgb(65, 65, 65));
@@ -182,9 +182,9 @@ LocalTrackGroupView #groupNameField
 
 LocalTrackGroupView #groupNameField:focus
 {
-    color: rgb(140, 140, 140);
+    color: rgb(150, 150, 150);
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(55, 55, 55),
+    stop:0 rgb(50, 50, 50),
     stop:1 rgb(65, 65, 65));
-    border: 1px solid rgb(60, 60, 60);
+    border: 1px solid rgb(54, 54, 54);
 }

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -1,9 +1,11 @@
 #userNamePanel
 {
     color: rgb(140, 140, 140);
-    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(45, 45, 45),
-    stop:1 rgb(65, 65, 65));
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+            stop:0 rgb(85, 85, 85),
+            stop:0.1 rgb(65, 65, 65)
+            stop:0.9 rgba(45, 45, 45),
+            stop:1 rgba(25, 25, 25));
     border: 1px solid rgb(55, 55, 55);
     padding: 1px;
 }

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -36,7 +36,7 @@
 
 #userNameLineEdit:read-only
 {
-    color: rgb(140, 140, 140);
+    color: rgb(100, 100, 100);
 }
 
 /* ------------------------------ */

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -36,7 +36,7 @@
 
 #userNameLineEdit:read-only
 {
-    color: rgb(85, 85, 85);
+    color: rgb(140, 140, 140);
 }
 
 /* ------------------------------ */

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -1,7 +1,7 @@
 #userNamePanel
 {
-    background-color: rgb(20, 20, 20);
-    border-color: black;
+    background-color: rgb(35, 35, 35);
+    border-color: rgba(0, 0, 0, 90);;
     padding: 1px;
 }
 

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -79,5 +79,5 @@ QMainWindow
 #chatTabWidget QTabBar::tab
 {
     background-color: rgb(20, 20, 20);
-    color: white;
+    color: rgb(140, 140, 140);
 }

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -16,7 +16,7 @@
 #masterTitleLabel,
 #labelMetronomeIControls
 {
-    color: rgb(85, 85, 85);
+    color: rgb(90, 90, 90);
 }
 
 #masterMeterL,

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -1,7 +1,10 @@
 #userNamePanel
 {
-    background-color: rgb(35, 35, 35);
-    border-color: rgba(0, 0, 0, 90);;
+    color: rgb(140, 140, 140);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(45, 45, 45),
+    stop:1 rgb(65, 65, 65));
+    border: 1px solid rgb(55, 55, 55);
     padding: 1px;
 }
 

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -54,10 +54,10 @@ QMainWindow
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(50, 50, 50),
     stop:1 rgb(10, 10, 10));
-    border-top: 1px solid Black;
-    border-left: 1px solid Black;
-    border-right: 1px solid Black;
-    border-bottom: 1px solid Black;
+    border-top: 1px solid rgb(30, 30, 30);
+    border-left: 1px solid rgb(30, 30, 30);
+    border-right: 1px solid rgb(30, 30, 30);
+    border-bottom: 1px solid rgb(30, 30, 30);
 }
 
 #leftPanel

--- a/src/resources/css/themes/Black/MainWindow.css
+++ b/src/resources/css/themes/Black/MainWindow.css
@@ -29,7 +29,7 @@
 
 #userNameLineEdit
 {
-    color: rgb(140, 140, 140);
+    color: rgb(150, 150, 150);
     background-color: transparent;
     border: none;
 }

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -98,6 +98,25 @@ NinjamTrackView[unlighted="true"]           /* user is not xmiting */
     background: rgba(0, 0, 0, 20);
 }
 
+NinjamTrackGroupView #groupNameField                          /* the text field used to input channel name */
+{
+    color: black;
+    margin-bottom: 0px;
+    margin-top: 0px;
+    font-size: 11px;
+    font-weight: normal;
+    border: rgb(80, 80, 80);
+    background-color: rgb(35, 35, 35);
+}
+
+NinjamTrackGroupView[unlighted="true"] #groupNameField        /* channel name text field when not xmiting */
+{
+    color: black;
+    background: rgba(255, 255, 255, 20);
+    border: none;
+}
+
+
 NinjamTrackView  #channelName               /* channel name for ninjamers */
 {
     border: none;

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -152,9 +152,10 @@ NinjamPanel QComboBox
     background-color: rgba(0, 0, 0, 30);
 }
 
-
-
-
+NinjamTrackGroupView > #topPanel                /* the track group top panel: used to show user name */
+{
+    background: rgba(255, 255, 255, 50);
+}
 
 NinjamTrackGroupView                        /* ninjam track group. If a ninjamer is using 2 channels they will appear grouped */
 {

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -146,5 +146,10 @@ IntervalProgressWindow                      /* The floating window showing the m
 
 #panelCombos QLabel             /* The labels in left side of comboboxes (bpi, bpm, accents and shape) */
 {
-    color: rgb(80, 80, 80);
+    color: rgb(180, 180, 180);
+}
+
+#panelCombos QComboBox
+{
+    color: rgb(140, 140, 140);
 }

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -168,9 +168,12 @@ NinjamTrackGroupView                        /* ninjam track group. If a ninjamer
 }
 
 
-IntervalProgressWindow                      /* The floating window showing the metronome/interval progress */
+/** The floating window showing the metronome/interval progress */
+IntervalProgressWindow
 {
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop: 0.8     rgb(50, 50, 50),
+    stop: 1.0   rgba(30, 30, 30));
 }
 
 #panelCombos QLabel             /* The labels in left side of comboboxes (bpi, bpm, accents and shape) */

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -133,7 +133,6 @@ NinjamTrackGroupView[unlighted="true"] #groupNameField        /* channel name te
 NinjamTrackView  #channelName               /* channel name for ninjamers */
 {
     border-color: rgb(20, 20, 20);
-    background-color: rgb(80, 80, 80);
     padding-top: 3px;
     padding-bottom: 3px;
     font-size: 10px;

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -52,18 +52,23 @@ NinjamTrackView[horizontal="true"]
     width: 28px;
 }
 
-NinjamRoomWindow QToolButton:hover,
+NinjamRoomWindow QToolButton:hover
+{
+    border: 1px solid black;
+    background-color: rgb(60, 60, 60);
+}
+
 #licenceButton:hover
 {
     border: 1px solid black;
-    background-color: rgb(80, 80, 80);
+    background-color: rgb(35, 35, 35);
 }
 
 NinjamRoomWindow QToolButton:hover:checked,
 #licenceButton:hover:checked
 {
     border: 1px solid black;
-    background-color: rgb(80, 80, 80);
+    background-color: rgb(30, 30, 30);
 }
 
 NinjamRoomWindow QToolButton,

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -1,4 +1,7 @@
-
+NinjamTrackView[horizontal="true"] #panSlider
+{
+    max-width: 50px;
+}
 
 NinjamTrackView[horizontal="true"] #buttonBoostMinus12,
 NinjamTrackView[horizontal="true"] #buttonBoostPlus12,

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -37,9 +37,9 @@ NinjamTrackView[horizontal="true"] QPushButton#buttonBoostZero:checked
 
 NinjamTrackView[horizontal="true"]
 {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-        stop:0 rgb(240, 240, 240),
-        stop:1 rgb(200, 200, 200));
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgb(80, 80, 80),
+        stop:1 rgb(20, 20, 20));
 }
 
 /* Tool buttons: track vertical/horizontal, wide/narrow and server licence buttons

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -122,6 +122,11 @@ NinjamRoomWindow #labelUserName
     color: rgb(140, 140, 140);
 }
 
+NinjamRoomWindow #labelBpmBpi
+{
+    color: rgb(70, 70, 70);
+}
+
 /* Ninjam tracks
 -----------------------------------------*/
 

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -108,14 +108,15 @@ NinjamRoomWindow #labelUserName
 
 NinjamTrackView[unlighted="true"] #channelName              /* user is not xmiting */
 {
+    color: rgb(80, 80, 80);
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(70, 70, 70),
-    stop:1 rgb(50, 50, 50));
-    border: 1px solid rgb(60, 60, 60);
+    stop:0 rgb(50, 50, 50),
+    stop:1 rgb(60, 60, 60));
+    border: 1px solid rgb(55, 55, 55);
 }
 
 
-NinjamTrackView  #channelName               /* channel name for ninjamers */
+NinjamTrackView  #channelName               /* channel name for ninjamers XMIT ON */
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(60, 60, 60),
@@ -124,7 +125,7 @@ NinjamTrackView  #channelName               /* channel name for ninjamers */
     padding-top: 3px;
     padding-bottom: 3px;
     font-size: 10px;
-    color: rgb(140, 140, 140);;
+    color: rgb(140, 140, 140);
     max-width: 130px;
 }
 

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -179,7 +179,12 @@ NinjamPanel QComboBox
 
 NinjamTrackGroupView > #topPanel                /* the track group top panel: used to show user name */
 {
-    background: rgba(255, 255, 255, 50);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(30, 30, 30),
+    stop:1 rgb(70, 70, 70));
+
+    border-top-left-radius: 1px;
+    border-top-right-radius: 1px;
 }
 
 NinjamTrackGroupView                        /* ninjam track group. If a ninjamer is using 2 channels they will appear grouped */

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -46,6 +46,7 @@ NinjamTrackView[horizontal="true"]
 ------------------------------------------------------------------------------------*/
 #licenceButton
 {
+    background-color: rgb(50, 50, 50);
     border: 1px solid black;
     max-height: 20px;
     width: 28px;
@@ -55,14 +56,14 @@ NinjamRoomWindow QToolButton:hover,
 #licenceButton:hover
 {
     border: 1px solid black;
-    background-color: rgb(120, 120, 120);
+    background-color: rgb(80, 80, 80);
 }
 
 NinjamRoomWindow QToolButton:hover:checked,
 #licenceButton:hover:checked
 {
     border: 1px solid black;
-    background-color: rgb(140, 140, 140);
+    background-color: rgb(80, 80, 80);
 }
 
 NinjamRoomWindow QToolButton,
@@ -74,6 +75,7 @@ NinjamRoomWindow QToolButton,
 
 NinjamRoomWindow QToolButton
 {
+    background-color: rgb(50, 50, 50);
     border: 1px solid black;
     height: 20px;
     min-width: 28px;
@@ -83,7 +85,7 @@ NinjamRoomWindow QToolButton
 NinjamRoomWindow QToolButton:checked
 {
     border: 1px solid black;
-    background-color: rgb(60, 60, 60);
+    background-color: rgb(20, 20, 20);
 }
 
 

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -102,7 +102,7 @@ NinjamRoomWindow QToolButton#buttonHorizontalLayout:!checked
 
 NinjamRoomWindow #labelUserName
 {
-    color: rgb(80, 80, 80);
+    color: rgb(140, 140, 140);
 }
 
 /* Ninjam tracks

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -106,33 +106,21 @@ NinjamRoomWindow #labelUserName
 /* Ninjam tracks
 -----------------------------------------*/
 
-NinjamTrackView[unlighted="true"]           /* user is not xmiting */
+NinjamTrackView[unlighted="true"] #channelName              /* user is not xmiting */
 {
-    background: rgba(0, 0, 0, 20);
-}
-
-NinjamTrackGroupView #groupNameField                          /* the text field used to input channel name */
-{
-    color: black;
-    margin-bottom: 0px;
-    margin-top: 0px;
-    font-size: 11px;
-    font-weight: normal;
-    border: rgb(80, 80, 80);
-    background-color: rgb(35, 35, 35);
-}
-
-NinjamTrackGroupView[unlighted="true"] #groupNameField        /* channel name text field when not xmiting */
-{
-    color: black;
-    background: rgba(255, 255, 255, 20);
-    border: none;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(70, 70, 70),
+    stop:1 rgb(50, 50, 50));
+    border: 1px solid rgb(60, 60, 60);
 }
 
 
 NinjamTrackView  #channelName               /* channel name for ninjamers */
 {
-    border-color: rgb(20, 20, 20);
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(60, 60, 60),
+    stop:1 rgb(80, 80, 80));
+    border: 1px solid rgb(70, 70, 70);
     padding-top: 3px;
     padding-bottom: 3px;
     font-size: 10px;

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -114,8 +114,8 @@ NinjamTrackView  #channelName               /* channel name for ninjamers */
 ----------------------------------------------------------------------------------------------------------------*/
 NinjamPanel #ninjamControlsPanel
 {
-    background-color: rgba(0, 0, 0, 20);
-    border: 1px solid rgb(140, 140, 140);
+    background-color: rgba(0, 0, 0, 30);
+    border: 1px solid rgb(20, 20, 20);
 }
 
 NinjamPanel #soloButton,

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -176,3 +176,11 @@ IntervalProgressWindow                      /* The floating window showing the m
 {
     color: rgb(140, 140, 140);
 }
+
+#panelCombos QComboBox QAbstractItemView
+{
+    border: 1px solid black;
+    color: rgb(180, 180, 180);
+    background-color: rgb(20, 20, 20);
+    selection-background-color: rgb(80, 80, 80);
+}

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -46,6 +46,7 @@ NinjamTrackView[horizontal="true"]
 ------------------------------------------------------------------------------------*/
 #licenceButton
 {
+    border: 1px solid black;
     max-height: 20px;
     width: 28px;
 }
@@ -53,19 +54,27 @@ NinjamTrackView[horizontal="true"]
 NinjamRoomWindow QToolButton:hover,
 #licenceButton:hover
 {
-    border: 1px solid rgba(0, 0, 0, 50);
-    background-color: rgba(255, 255, 255, 80);
+    border: 1px solid black;
+    background-color: rgb(120, 120, 120);
+}
+
+NinjamRoomWindow QToolButton:hover:checked,
+#licenceButton:hover:checked
+{
+    border: 1px solid black;
+    background-color: rgb(140, 140, 140);
 }
 
 NinjamRoomWindow QToolButton,
 #licenceButton
 {
-    border: 1px solid rgb(150, 150, 150);
+    border: 1px solid black;
     background-color: rgba(255, 255, 255, 10);
 }
 
 NinjamRoomWindow QToolButton
 {
+    border: 1px solid black;
     height: 20px;
     min-width: 28px;
     padding: 0px;
@@ -73,15 +82,19 @@ NinjamRoomWindow QToolButton
 
 NinjamRoomWindow QToolButton:checked
 {
-    background-color: rgba(255, 255, 255, 60);
-    border: 1px solid rgb(130, 130, 130);
+    border: 1px solid black;
+    background-color: rgb(60, 60, 60);
 }
 
 
-NinjamRoomWindow QToolButton#buttonVerticalLayout:!checked{
+NinjamRoomWindow QToolButton#buttonVerticalLayout:!checked
+{
+    border: 1px solid black;
     border-right-color: none;
 }
-NinjamRoomWindow QToolButton#buttonHorizontalLayout:!checked{
+NinjamRoomWindow QToolButton#buttonHorizontalLayout:!checked
+{
+    border: 1px solid black;
     border-left-color: none;
 }
 

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -119,14 +119,15 @@ NinjamTrackGroupView[unlighted="true"] #groupNameField        /* channel name te
 
 NinjamTrackView  #channelName               /* channel name for ninjamers */
 {
-    border: none;
-    background-color: rgba(0, 0, 0, 6);
+    border-color: rgb(20, 20, 20);
+    background-color: rgb(80, 80, 80);
     padding-top: 3px;
     padding-bottom: 3px;
     font-size: 10px;
-    color: rgba(0, 0, 0, 160);
+    color: rgb(140, 140, 140);;
     max-width: 130px;
 }
+
 
 
 /* NinjamPanel is the widget where the ninjam controls are showed (in bottom when we are connected in a server)

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -42,6 +42,18 @@ NinjamTrackView[horizontal="true"]
         stop:1 rgb(20, 20, 20));
 }
 
+NinjamTrackView[unlighted="true"][horizontal="true"] QSlider::handle:horizontal
+{
+    border: rgb(140, 140, 140);
+    background: rgb(80, 80, 80);
+}
+
+NinjamTrackView[horizontal="true"] QSlider::handle:horizontal
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
+    border: 1px outset rgb(30, 30, 30);
+}
+
 /* Tool buttons: track vertical/horizontal, wide/narrow and server licence buttons
 ------------------------------------------------------------------------------------*/
 #licenceButton

--- a/src/resources/css/themes/Black/PublicRooms.css
+++ b/src/resources/css/themes/Black/PublicRooms.css
@@ -2,7 +2,7 @@
 
 JamRoomViewPanel
 {
-    background-color: rgb(40, 40, 40);
+    background-color: rgb(35, 35, 35);
     border: 1px solid black;
     border-top: 1px solid black;
     border-left: 1px solid black;
@@ -12,7 +12,7 @@ JamRoomViewPanel
 JamRoomViewPanel #content                   /* where the user names and wave form are showed */
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(60, 60, 60),
+    stop:0 rgb(70, 70, 70),
     stop:1 rgb(20, 20, 20));
 }
 

--- a/src/resources/css/themes/Black/PublicRooms.css
+++ b/src/resources/css/themes/Black/PublicRooms.css
@@ -13,7 +13,7 @@ JamRoomViewPanel #content                   /* where the user names and wave for
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 rgb(70, 70, 70),
-    stop:1 rgb(20, 20, 20));
+    stop:1 rgb(25, 25, 25));
 }
 
 JamRoomViewPanel #labelName             /* the server name (ninbot.com, ninjamer.com, etc) */

--- a/src/resources/css/themes/Black/PublicRooms.css
+++ b/src/resources/css/themes/Black/PublicRooms.css
@@ -2,7 +2,7 @@
 
 JamRoomViewPanel
 {
-    background-color: rgb(20, 20, 20);
+    background-color: rgb(40, 40, 40);
     border: 1px solid black;
     border-top: 1px solid black;
     border-left: 1px solid black;
@@ -12,8 +12,8 @@ JamRoomViewPanel
 JamRoomViewPanel #content                   /* where the user names and wave form are showed */
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-    stop:0 rgb(40, 40, 40),
-    stop:1 rgb(10, 10, 10));
+    stop:0 rgb(60, 60, 60),
+    stop:1 rgb(20, 20, 20));
 }
 
 JamRoomViewPanel #labelName             /* the server name (ninbot.com, ninjamer.com, etc) */


### PR DESCRIPTION
- [x] Basic implementation for the black theme.
- [x] change text color of the JamRoomViewPanel (musicians, server) to white.
- [x] change busy dialog background to gray. 
- [x] change the text color of BPI/BPM, etc. to white inside server.
- [x] change channel name text color to white or black.
- [x] change the background and text color of the _server_ tab and _rooms to play_ tab.
- [x] change buttons colors
- [x] correct hover colors for faders.
- [x] correct hover colors of buttons and Xmit button (red, green, yellow).
- [x] use the :hover effect when the button is unchecked too.
- [x] Correct Pan Slider color (too dim).
- [x] Use green and red colors for Xmit and Xmit-disabled modes in normal state too (not only hover)
- [x] Listen and enter buttons should follow the same hover and checked rules for the Base Track.
- [x] Label used to show max peak below peak meters needs to be brighter.
- [x] "new effect".....too white
- [x] input border and text color.....too white (do not match)
- [x] pan color a bit mismatched (too bright)
- [x] "stereo inverted" button border in xmit-disabled is black. correct this
- [x] xmit button in xmit-disabled is a bit bright
- [x] fader hover color in xmit-disabled track is not working (pan is working ATM).
- [x] fixed preparing yellow to match green-red palette
- [x] loading rooms dialog border too white....change to gray
- [x] Transmitting text color (black) not matched with the other text (lightgray)
- [x] Tools button color and border in xmit-disabled mode not matching overall pallette.
- [x] lighter border for public rooms.
- [x] player's tracks have a disabled/muted appearance.
- [x] bpi/bpm texts colors are mismatched (too gray/black). Need more bright.
- [x] _rooms to play_ and _server_ tabs' hover is not working
- [x] Hover not working in inverse stereo button
- [x] Add a little gradient to buttons (xmit, M, S, etc.) as in rounded theme
- [x] white background mismatch when selecting BPM/BPI, etc.
- [x]  Gradient for vst slot button.
- [x]  Darker wide.narrow/wide and horizontal/vertical buttons non check status.
- [x]  Listen and enter buttons correct text color (similar to gain/miditools buttons text color (dark))
- [x] QLineEdit objects have wrong color in Preferences and dialog menu colors.
- [x] correct colors for metronome floating window
- [x] some pan and fader handles in ninjamer channel in horizontal tracks layout has the wrong color (enabled/disabled).
- [x]  Improve gradient for channel name and input name.
- [x] Blurry volume icon for basetrack.
- [x] Plugin Scan Dialog white line doesn't look good
- [x] add gradients to scroll bars
- [x] final review and corrections.