### PR TITLE
Theme menu color change

### DIFF
--- a/src/resources/css/themes/Flat/General.css
+++ b/src/resources/css/themes/Flat/General.css
@@ -209,6 +209,10 @@ QMenuBar::item
 QMenuBar
 {
     background:rgb(225, 225, 225);
+    border-bottom: none;
+    border-top: 1px solid rgb(90, 90, 90);
+    border-left: 1px solid rgb(90, 90, 90);
+    border-right: 1px solid rgbrgb(90, 90, 90);
 }
 
 QMenu

--- a/src/resources/css/themes/Flat/General.css
+++ b/src/resources/css/themes/Flat/General.css
@@ -199,3 +199,23 @@ QTabBar::tab:!selected
     margin-top: 3px; /* make non-selected tabs look smaller */
     color: rgb(90, 90, 90);
 }
+
+QMenuBar::item
+{
+    color: black;
+    background:rgb(225, 225, 225);
+}
+
+QMenuBar
+{
+    background:rgb(225, 225, 225);
+}
+
+QMenu
+{
+    border: 1px outset rgb(80, 80, 80);
+    color: black;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 rgb(250, 250, 250),
+    stop:1 rgb(230, 230, 230));
+}

--- a/src/resources/css/themes/Rounded/General.css
+++ b/src/resources/css/themes/Rounded/General.css
@@ -278,3 +278,23 @@ QTabBar::tab:!selected {
     margin-top: 3px; /* make non-selected tabs look smaller */
     color: rgb(90, 90, 90);
 }
+
+QMenuBar::item
+{
+    color: black;
+    background:rgb(225, 225, 225);
+}
+
+QMenuBar
+{
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop:0 #EAEAEA,
+    stop:1 #CACACA);
+}
+
+QMenu
+{
+    border: 1px outset rgb(80, 80, 80);
+    color: black;
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1, stop:0 rgb(245, 245, 245), stop:1 rgb(210, 210, 210));
+}

--- a/src/resources/css/themes/Rounded/General.css
+++ b/src/resources/css/themes/Rounded/General.css
@@ -290,6 +290,10 @@ QMenuBar
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
     stop:0 #EAEAEA,
     stop:1 #CACACA);
+    border-bottom: none;
+    border-top: 1px solid rgb(70, 70, 70);
+    border-left: 1px solid rgb(70, 70, 70);
+    border-right: 1px solid rgb(70, 70, 70);
 }
 
 QMenu


### PR DESCRIPTION
Flat theme menu color match:

![image](https://cloud.githubusercontent.com/assets/15310433/15550942/108f76be-228a-11e6-85a9-8bd099e2ee89.png)

EDIT: Maybe a little softer menu color for Flat

Round theme menu color match:

![image](https://cloud.githubusercontent.com/assets/15310433/15551210/5c91dc7c-228b-11e6-9228-788509de1aa7.png)

![image](https://cloud.githubusercontent.com/assets/15310433/15551847/325f86c2-228e-11e6-87b2-99b9e75d3888.png)

EDIT: Probably this one needs a bit modification too. The menu looks too sharp compared to the ninjam tracks.