### PR TITLE
muted basetrack color fix

### DIFF
--- a/src/resources/css/themes/Rounded/BaseTrack.css
+++ b/src/resources/css/themes/Rounded/BaseTrack.css
@@ -96,11 +96,12 @@ BaseTrackView
    font-size: 8px; /*db value */
 }
 
-BaseTrackView[unlighted="true"]             /* track when is not xmiting */
+BaseTrackView[unlighted="true"],                            /* the track */
+TrackGroupView[unlighted="true"] > #topPanel                /* the track group top panel: used to show user name */
 {
     background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop:0 rgb(150, 150, 150),
-        stop:1 rgb(90, 90, 90));
+    stop:0 rgb(150, 150, 150),
+    stop:1 rgb(90, 90, 90));
 }
 
 PeakMeter


### PR DESCRIPTION
@elieserdejesus Track layout don't have problems here:

![image](https://cloud.githubusercontent.com/assets/15310433/15588702/7c6c3ea4-2365-11e6-8d6a-04a4b3c8fdf5.png)

The solution in this case was simply to use the Flat theme code that was working and use the original rounded gradient that was there. Can't tell why this was hapenning, just did a quick fix keeping the intended colors.