### PR TITLE
Flat Theme top panel color fix to avoid track layer mismatch illusion

### DIFF
--- a/src/resources/css/themes/Flat/NinjamWindow.css
+++ b/src/resources/css/themes/Flat/NinjamWindow.css
@@ -105,6 +105,11 @@ NinjamTrackView  #channelName               /* channel name for ninjamers */
     max-width: 130px;
 }
 
+NinjamTrackGroupView > #topPanel                /* the track group top panel: used to show user name */
+ {
+     background: rgba(255, 255, 255, 180);
+ }
+
 
 /* NinjamPanel is the widget where the ninjam controls are showed (in bottom when we are connected in a server)
 ----------------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
This is the final result:

![image](https://cloud.githubusercontent.com/assets/15310433/15590451/49fd73da-236e-11e6-874a-bf3539361db4.png)
