### PR TITLE
Shortcuts for Peak meter and RMS meter only

### DIFF
--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -33,6 +33,8 @@ void MainWindowStandalone::setupShortcuts()
     ui.actionMetronome->setShortcut(QKeySequence(Qt::Key_F9));
     ui.actionUsersManual->setShortcut(QKeySequence(Qt::Key_F1));
     ui.actionPrivate_Server->setShortcut(QKeySequence(Qt::Key_F2));
+    ui.actionShowRmsOnly->setShortcut(QKeySequence(Qt::Key_F3));
+    ui.actionShowPeaksOnly->setShortcut(QKeySequence(Qt::Key_F4));
     ui.actionQuit->setShortcut(QKeySequence(Qt::Key_Escape));
     ui.actionFullscreenMode->setShortcut(QKeySequence(Qt::Key_F11));
 }


### PR DESCRIPTION
I found it's handy to be able to switch fast from PEAK meter to RMS meter and back to see the difference or maybe just to make adjustments in levels and switch back again. I propose use F3 (RMS) and F4 (PEAK)