### PR TITLE
Rounded theme Horizontal track color correction

### DIFF
--- a/src/resources/css/themes/Rounded/NinjamWindow.css
+++ b/src/resources/css/themes/Rounded/NinjamWindow.css
@@ -46,6 +46,12 @@ NinjamTrackGroupView                        /* track group in ninjam window */
     border-top-right-radius: 2px;
 }
 
+NinjamTrackView[horizontal="true"][unlighted="true"]
+{
+    background: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop:0 rgb(150, 150, 150),
+        stop:1 rgb(90, 90, 90));
+}
 
 /* buttons in ninjam track when using horizontal layout
 -------------------------------------------------------------*/


### PR DESCRIPTION
This PR corrects the Color of the disabled track in horizontal layout for the muted ninjam room track.

![image](https://cloud.githubusercontent.com/assets/15310433/15635958/02e87d28-25c6-11e6-9516-64a384645292.png)
