### PR TITLE
StInv button hover (check) color correction

### DIFF
--- a/src/resources/css/themes/Black/BaseTrack.css
+++ b/src/resources/css/themes/Black/BaseTrack.css
@@ -143,6 +143,12 @@ BaseTrackView[unlighted="true"] #buttonStereoInversion
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
     color: rgb(80, 80, 80);
 }
+
+BaseTrackView[unlighted="true"] #buttonStereoInversion:hover, #buttonStereoInversion:hover:checked
+{
+    background-color: rgba(0, 0, 0, 80);
+}
+
 /* Small Label used to show max peak below peak meters
 -------------------------------------------------------*/
 BaseTrackView #peaksDbLabel


### PR DESCRIPTION
This PR adds the code for the color of the Stereo Inversion button in hover and hover-check modes when basetrack is not transmitting for the Black theme. Before it used the same bright color as the one in xmit mode.