### PR TITLE
Rounded StInv button hover (check) color fix

### DIFF
--- a/src/resources/css/themes/Rounded/BaseTrack.css
+++ b/src/resources/css/themes/Rounded/BaseTrack.css
@@ -172,7 +172,11 @@ BaseTrackView[unlighted="true"] .QPushButton
    background-color: rgb(100, 100, 100);
 }
 
-
+BaseTrackView[unlighted="true"] #buttonStereoInversion:hover,
+BaseTrackView[unlighted="true"] #buttonStereoInversion:hover:checked
+{
+    background-color: rgba(0, 0, 0, 45);
+}
 
 /* track group
 ------------------------------------ */


### PR DESCRIPTION
This PR adds the code for the color of the Stereo Inversion button in hover and hover-check modes when basetrack is not transmitting for the Rounded theme.