### PR TITLE
Translate Button background color match

### DIFF
--- a/src/resources/css/common/Chat.css
+++ b/src/resources/css/common/Chat.css
@@ -46,6 +46,11 @@ ChatMessagePanel #labelUserName /* chat message author */
     font-weight: bold;
 }
 
+ChatMessagePanel #translateButton
+{
+    background-color: transparent;
+}
+
 ChatMessagePanel #translateButton, /* the small T (translate) button in right side of chat messages */
 ChatMessagePanel #blockButton      /* the small B (block user in chat) button */
 {


### PR DESCRIPTION
This PR makes the translate button inside the chat widget transparent to avoid color mismatch with the new background from https://github.com/elieserdejesus/JamTaba/commit/eba63bcf6dc830b4c0253e984cb69fa898bf2631