### PR TITLE
little typing mistake in german translation

### DIFF
--- a/translations/de_DE.ts
+++ b/translations/de_DE.ts
@@ -736,7 +736,7 @@
     </message>
     <message>
         <source>%1 is blocked in the chat</source>
-        <translationt>%1 ist geblockt im cha</translation>
+        <translationt>%1 ist geblockt im chat</translation>
     </message>
     <message>
         <source>%1 is unblocked in the chat</source>

--- a/translations/de_DE.ts
+++ b/translations/de_DE.ts
@@ -736,7 +736,7 @@
     </message>
     <message>
         <source>%1 is blocked in the chat</source>
-        <translationt>%1 ist geblockt im chat</translation>
+        <translation>%1 ist geblockt im chat</translation>
     </message>
     <message>
         <source>%1 is unblocked in the chat</source>


### PR DESCRIPTION
Just added the "t" to "cha" L. 739