### PR TITLE
New values for Encoder quality

### DIFF
--- a/src/Common/audio/vorbis/VorbisEncoder.cpp
+++ b/src/Common/audio/vorbis/VorbisEncoder.cpp
@@ -6,9 +6,9 @@
 
 
 //these vorbis quality values are discussed here: https://github.com/elieserdejesus/JamTaba/issues/456#issuecomment-226920734
-const float VorbisEncoder::QUALITY_LOW    = -0.1f; // ~64 kbps
-const float VorbisEncoder::QUALITY_NORMAL =  0.2f; // ~96 – ~112 kbps. In ogg vorbis 96 Kbps is similar to 128 kbps mp3
-const float VorbisEncoder::QUALITY_HIGH   =  0.3f;  // ~112 – ~128 kbps
+const float VorbisEncoder::QUALITY_LOW    = -0.1f; // ~48 – ~64 kbps
+const float VorbisEncoder::QUALITY_NORMAL =  0; // ~64 – ~80 kbps. 
+const float VorbisEncoder::QUALITY_HIGH   =  0.3f;  // ~112 – ~128 kbps. In ogg vorbis 112 Kbps is better than 128 kbps mp3
 
 VorbisEncoder::VorbisEncoder()
     :initialized(false)


### PR DESCRIPTION
QUALITY_LOW    = -0.1f; // ~48 – ~64 kbps
QUALITY_NORMAL =  0; // ~64 – ~80 kbps. 
QUALITY_HIGH   =  0.3f; // ~112 – ~128 kbps.