### PR TITLE
Fix chat message context menu

### DIFF
--- a/src/Common/gui/chat/ChatMessagePanel.cpp
+++ b/src/Common/gui/chat/ChatMessagePanel.cpp
@@ -26,7 +26,12 @@ ChatMessagePanel::ChatMessagePanel(QWidget *parent, const QString &userName, con
     ui->setupUi(this);
     initialize(userName, msg, userNameBackgroundColor, textColor, showTranslationButton, showBlockButton);
     connect(ui->blockButton, SIGNAL(clicked(bool)), this, SLOT(fireBlockingUserSignal()));
+}
 
+void ChatMessagePanel::focusInEvent(QFocusEvent *ev)
+{
+    QFrame::focusInEvent(ev);
+    ui->labelMessage->setFocus();
 }
 
 void ChatMessagePanel::changeEvent(QEvent *e)

--- a/src/Common/gui/chat/ChatMessagePanel.h
+++ b/src/Common/gui/chat/ChatMessagePanel.h
@@ -27,7 +27,7 @@ signals:
 
 protected:
     void changeEvent(QEvent *) override;
-
+    void focusInEvent(QFocusEvent *) override;
 private slots:
     void on_translateButton_clicked();
     void fireBlockingUserSignal();

--- a/src/Common/gui/chat/ChatMessagePanel.ui
+++ b/src/Common/gui/chat/ChatMessagePanel.ui
@@ -16,6 +16,9 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="focusPolicy">
+   <enum>Qt::ClickFocus</enum>
+  </property>
   <property name="windowTitle">
    <string notr="true"/>
   </property>
@@ -95,6 +98,9 @@
    </item>
    <item>
     <widget class="QLabel" name="labelMessage">
+     <property name="focusPolicy">
+      <enum>Qt::ClickFocus</enum>
+     </property>
      <property name="text">
       <string notr="true">big text to test the multiline behavior when using vbery big texts</string>
      </property>

--- a/src/resources/css/common/General.css
+++ b/src/resources/css/common/General.css
@@ -97,3 +97,9 @@ QMenuBar::item:pressed { /* 'button pressed' item style */
     border-style: inset;
 
 }
+
+/* fix to issue #500 */
+QMenu::item::disabled
+{
+    color: rgba(0, 0, 0, 120);
+}

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -303,6 +303,7 @@ QMenu
 QMenu::item:selected
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(60, 60, 60), stop:1 rgb(40, 40, 40));
+    color: black; /* fix to issue #500 */
 }
 
 QTabWidget::pane


### PR DESCRIPTION
Working in issue #500

The "non working" menu items are just a problem of stylesheet. The previous code was using same color for disabled and enabled menu items. Now the copy, paste, select all options appear with different colors when disabled.

Control + A and Control + C working for chat messages.