### PR TITLE
BLACK theme Chat message selection color match

### DIFF
--- a/src/resources/css/themes/Black/Chat.css
+++ b/src/resources/css/themes/Black/Chat.css
@@ -44,4 +44,8 @@ ChatMessagePanel #blockButton:hover
     font-weight: bold;
 }
 
-
+ChatMessagePanel #labelMessage
+{
+    selection-background-color: rgb(50, 50, 50);
+    selection-color: rgb(140, 140, 140)
+}


### PR DESCRIPTION
changed from this:

![image](https://cloud.githubusercontent.com/assets/15310433/18227997/c9cb5692-720e-11e6-93bf-82be318e4674.png)


to this:

![image](https://cloud.githubusercontent.com/assets/15310433/18227992/b266caae-720e-11e6-9b35-8691fb535c8c.png)
