### PR TITLE
es_CL update

### DIFF
--- a/translations/es_CL.ts
+++ b/translations/es_CL.ts
@@ -528,7 +528,7 @@
     </message>
     <message>
         <source>Volcano</source>
-        <translation type="unfinished"></translation>
+        <translation>Volcánico</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
The proper translation for **Volcano** in Spanish is **Volcán**, but I think it sounds pretty bad for a theme, so I used the translation of the word **Volcanic** that is much better.