### PR TITLE
improving and matching colors for all themes (comboboxes and selections)

### DIFF
--- a/src/resources/css/common/NinjamWindow.css
+++ b/src/resources/css/common/NinjamWindow.css
@@ -7,7 +7,7 @@
 
 NinjamRoomWindow #labelBpmBpi                                /* label used to show current bpi and bpm values inside ninjam room window */
 {
-    color: rgba(0, 0, 0, 100);
+    color: black;
     font-size: 9px;
 }
 
@@ -74,7 +74,7 @@ NinjamPanel #intervalPanel                  /* The widget used to show ninjam co
 
 #panelCombos QLabel             /* The labels in left side of comboboxes (bpi, bpm, accents and shape) */
 {
-    color: black;
+    color: rgba(0, 0, 0, 170);
 }
 
 #panelCombos QComboBox::down-arrow

--- a/src/resources/css/common/NinjamWindow.css
+++ b/src/resources/css/common/NinjamWindow.css
@@ -235,11 +235,6 @@ NinjamTrackView[horizontal="true"] #muteButton
     padding-bottom: 0px;
 }
 
-NinjamTrackView  #channelName
-{
-    selection-background-color: rgba(0, 0, 0, 80);
-}
-
 /* Ninjam track groups
 ------------------------*/
 

--- a/src/resources/css/themes/Black/Chat.css
+++ b/src/resources/css/themes/Black/Chat.css
@@ -46,6 +46,6 @@ ChatMessagePanel #blockButton:hover
 
 ChatMessagePanel #labelMessage
 {
-    selection-background-color: rgb(50, 50, 50);
-    selection-color: rgb(140, 140, 140)
+    selection-background-color: rgb(120, 120, 120);
+    selection-color: rgb(40, 40, 40);;
 }

--- a/src/resources/css/themes/Black/General.css
+++ b/src/resources/css/themes/Black/General.css
@@ -178,7 +178,7 @@ QLineEdit#groupNameField:focus, #userNameLineEdit:focus
 {
     color: rgb(200, 200, 200);
     selection-background-color: rgb(120, 120, 120);
-    selection-color: rgb(80, 80, 80);
+    selection-color: rgb(40, 40, 40);
 }
 
 /*  SLIDERs ++++++++++++++++++++++++++++++++ */

--- a/src/resources/css/themes/Black/NinjamWindow.css
+++ b/src/resources/css/themes/Black/NinjamWindow.css
@@ -217,12 +217,14 @@ IntervalProgressWindow
 
 #panelCombos QLabel             /* The labels in left side of comboboxes (bpi, bpm, accents and shape) */
 {
-    color: rgb(180, 180, 180);
+    color: rgb(140, 140, 140);
 }
 
 #panelCombos QComboBox
 {
-    color: rgb(140, 140, 140);
+    color: rgb(180, 180, 180);
+    selection-background-color: rgb(80, 80, 80);
+    selection-color: rgb(10, 10, 10);;
 }
 
 #panelCombos QComboBox QAbstractItemView
@@ -231,6 +233,7 @@ IntervalProgressWindow
     color: rgb(180, 180, 180);
     background-color: rgb(20, 20, 20);
     selection-background-color: rgb(80, 80, 80);
+    selection-color: black;
 }
 
 NinjamPanel #intervalPanel,
@@ -239,6 +242,11 @@ IntervalProgressWindow #intervalPanel
     color: rgb(180, 180, 180);
 }
 
+NinjamTrackView  #channelName
+{
+    selection-background-color: rgb(120, 120, 120);
+    selection-color: rgb(40, 40, 40);
+}
 
 IntervalProgressDisplay
 {

--- a/src/resources/css/themes/Volcano/BaseTrack.css
+++ b/src/resources/css/themes/Volcano/BaseTrack.css
@@ -47,7 +47,7 @@ QPushButton#buttonStereoInversion:checked
 {
     background-color: #B35925;
     color: rgba(0, 0, 0, 160);
-    border-radius: 0px;
+    border-radius: 2px;
 }
 
 #buttonBoostMinus12:hover,
@@ -58,7 +58,7 @@ QPushButton#buttonStereoInversion:checked
 {
     background-color: #fed87b;
     color: rgb(80, 80, 80);
-    border-radius: 0px;
+    border-radius: 2px;
     border-color: rgb(40, 40, 40);
 }
 
@@ -73,7 +73,7 @@ QPushButton#buttonStereoInversion:hover
 #buttonBoostZero:hover:checked
 {
     background-color: #e56318;
-    border-radius: 0px;
+    border-radius: 2px;
     border-color: rgb(20, 20, 20)
 }
 

--- a/src/resources/css/themes/Volcano/Chat.css
+++ b/src/resources/css/themes/Volcano/Chat.css
@@ -42,6 +42,6 @@ ChatMessagePanel #blockButton:hover
 
 ChatMessagePanel #labelMessage
 {
-selection-background-color: rgb(179, 89, 37);
-selection-color: rgb(254, 181, 102);
+    selection-background-color: rgb(179, 89, 37);
+    selection-color: rgb(254, 181, 102);
 }

--- a/src/resources/css/themes/Volcano/General.css
+++ b/src/resources/css/themes/Volcano/General.css
@@ -167,7 +167,7 @@ QLineEdit:focus
     background-color: rgba(254, 181, 102, 150);
     color: black;
     selection-background-color: rgb(179, 89, 37);
-    selection-color: rgba(254, 181, 102, 150);
+    selection-color: rgb(254, 181, 102);
 }
 
 

--- a/src/resources/css/themes/Volcano/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano/NinjamWindow.css
@@ -161,11 +161,21 @@ NinjamPanel #muteButton
     stop: 1.0 #FFB301);
 }
 
+#panelCombos QLabel             /* The labels in left side of comboboxes (bpi, bpm, accents and shape) */
+{
+    color: rgb(40, 40, 40);
+}
+
 NinjamPanel QComboBox
 {
     background-color: rgba(0, 0, 0, 30);
-    selection-background-color: rgba(0, 0, 0, 90);
-    selection-color: rgba(254, 181, 102, 150);
+    selection-background-color: rgba(0, 0, 0, 160);
+    selection-color: rgb(254, 181, 102);
+}
+
+#panelCombos QComboBox
+{
+    color: rgb(10, 10, 10);
 }
 
 NinjamPanel QComboBox QAbstractItemView
@@ -174,11 +184,18 @@ border: none;
 color: black;
 background-color: rgb(176, 128, 94);
 selection-background-color: rgba(0, 0, 0, 90);
+selection-color: rgb(254, 181, 102);
 }
 
 NinjamTrackGroupView                        /* ninjam track group. If a ninjamer is using 2 channels they will appear grouped */
 {
     border: 1px solid rgb(130, 130, 130);
+}
+
+NinjamTrackView  #channelName
+{
+    selection-background-color: rgb(179, 89, 37);
+    selection-color: rgb(254, 181, 102);
 }
 
 /* The floating window showing the metronome/interval progress */


### PR DESCRIPTION
1.- I removed the selection color in the common file and matched themes individually

2.- Some improving and matching colors for the ninjam panel (the idea here is to dim a little the labels and bright the combo box information):

![image](https://cloud.githubusercontent.com/assets/15310433/18261493/56198882-73cf-11e6-9574-6b6007639ae8.png)

![image](https://cloud.githubusercontent.com/assets/15310433/18261496/5ce9cbf4-73cf-11e6-956d-b4385d8ed8f2.png)

![image](https://cloud.githubusercontent.com/assets/15310433/18262091/b5bdc276-73d4-11e6-9220-fb65a8a652d6.png)

![image](https://cloud.githubusercontent.com/assets/15310433/18262093/bac9e2ea-73d4-11e6-9508-ea51b3e97399.png)

3.- fixed squared buttons when hover for the volcano theme

