### PR TITLE
pl "your controls" text out of margin fix

### DIFF
--- a/translations/pl_PL.ts
+++ b/translations/pl_PL.ts
@@ -296,7 +296,7 @@
     <name>MainFrameClass</name>
     <message>
         <source>Your Controls</source>
-        <translation>TWOJA KONSOLKA</translation>
+        <translation>Twoja Konsolka</translation>
     </message>
     <message>
         <source>collapse/expand your controls ...</source>


### PR DESCRIPTION
low CAPS seem to fix the size problem:

from:

![image](https://cloud.githubusercontent.com/assets/15310433/20872310/32989724-ba7c-11e6-89d0-38bc517b7416.png)

to:

![image](https://cloud.githubusercontent.com/assets/15310433/20872323/48548fd2-ba7c-11e6-8ec9-2d237fd34672.png)
