### PR TITLE
de_DE syntax fix

### DIFF
--- a/translations/de_DE.ts
+++ b/translations/de_DE.ts
@@ -216,15 +216,15 @@
     </message>
     <message>
         <source>Delete preset</source>
-        <translation entferne voreinstellung</translation>
+        <translation>entferne voreinstellung</translation>
     </message>
     <message>
         <source>Deleting preset ...</source>
-        <translation entferne voreinstellung</translation>
+        <translation>entferne voreinstellung</translation>
     </message>
     <message>
         <source>You want to delete the preset &apos;%1&apos;</source>
-        <translation möchtest du das preset löschen &apos;%1&apos;</translation>
+        <translation>möchtest du das preset löschen &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -532,7 +532,7 @@
     </message>
     <message>
         <source>Error loading the theme %1</source>
-        <translation Fehler beim thema laden</translation>
+        <translation>Fehler beim thema laden</translation>
     </message>
 </context>
 <context>
@@ -744,11 +744,11 @@
     </message>
     <message>
         <source>%1 has left the room.</source>
-        <translation %1 hat den raum verlassen.</translation>
+        <translation>%1 hat den raum verlassen.</translation>
     </message>
     <message>
         <source>%1 has joined the room.</source>
-        <translation %1 hat den raum verlassen.</translation>
+        <translation>%1 hat den raum verlassen.</translation>
     </message>
 </context>
 <context>
@@ -756,32 +756,32 @@
     <message>
         <source>Host sync</source>
         <extracomment>This is the title of MessageDialot showed when user click in &quot;Sync with host&quot; button</extracomment>
-        <translation Das ist der titel des MessageDialog wenn der benutzer eintritt &quot;Sync with host&quot; button</extracomment></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The BPM is changed! Please stop %1 and change BPM to %2!</source>
-        <translation die BPM ist geändert! bitte stoppe %1 und ändere BPM zu %2!</source></translation>
+        <translation>die BPM ist geändert! bitte stoppe %1 und ändere BPM zu %2!</translation>
     </message>
     <message>
         <source>Sync with %1</source>
         <extracomment>The &apos;%1&apos; marker will be replaced by the host name when Jamtaba is running.</extracomment>
-        <translation The &apos;%1&apos; marker wird durch den host namen ersetzt wenn Jamtaba läuft.</extracomment></translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Synchronizing...</source>
-        <translation Syncronisiere...></translation>
+        <translation>Syncronisiere...</translation>
     </message>
     <message>
         <source>Press play/start in %1 to sync with Jamtaba!</source>
-        <translation drücke play/start in %1 zum syncen mit Jamtaba!</translation>
+        <translation>drücke play/start in %1 zum syncen mit Jamtaba!</translation>
     </message>
     <message>
         <source>Trying to sync ...</source>
-        <translation versuche zu syncen></translation>
+        <translation>versuche zu syncen</translation>
     </message>
     <message>
         <source>Change %1 BPM to %2 and try sync again!</source>
-        <translation ändere %1 BPM zu %2 und versuch nochmal zu syncen!</translation>
+        <translation>ändere %1 BPM zu %2 und versuch nochmal zu syncen!</translation>
     </message>
 </context>
 <context>
@@ -807,15 +807,15 @@
     </message>
     <message>
         <source>Off</source>
-        <translation aus</translation>
+        <translation>aus</translation>
     </message>
     <message>
         <source>Normal</source>
-        <translation normal</translation>
+        <translation>normal</translation>
     </message>
     <message>
         <source>Drastic</source>
-        <translation drastisch</translation>
+        <translation>drastisch</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
There were two phrases "Host sync" and "Sync with %1" that were not translated (the comment was translated instead) so I set them to unfinish for the moment.