### PR TITLE
match circle color palette for BLACK theme

### DIFF
--- a/src/resources/css/themes/Black_nm/PublicRooms.css
+++ b/src/resources/css/themes/Black_nm/PublicRooms.css
@@ -51,5 +51,5 @@ WavePeakPanel
     qproperty-peaksColor: white;
 
     /* color used to draw the loading circle */
-    qproperty-loadingColor: white;
+    qproperty-loadingColor: rgb(90, 90, 90);
 }


### PR DESCRIPTION
This is a matter of taste obviously, but I think the white color for the circle was a bit too bright. Gray matches better the overall darkness :D