### PR TITLE
Fixing themes exporting 

### DIFF
--- a/src/Common/Configurator.cpp
+++ b/src/Common/Configurator.cpp
@@ -151,8 +151,6 @@ bool Configurator::setUp()
     if (!folderTreeExists())
         createFoldersTree();
 
-
-
     exportThemes();
 
     qInfo() << "JamTaba Base dir:" << baseDir.absolutePath();
@@ -176,6 +174,8 @@ void Configurator::exportThemes() const
     QDir themesDir = getThemesDir();
     QStringList themesInResources = resourceDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
     QDateTime jamTabaCompilationDate = QDateTime::fromString(QString(__DATE__).simplified() + " " + QString(__TIME__).simplified(), "MMM d yyyy hh:mm:ss");
+
+    qDebug() << "Trying to export themes files JamTabaa compilationDate:" << jamTabaCompilationDate;
 
     for (const QString &themeDir : themesInResources) {
 
@@ -211,6 +211,13 @@ void Configurator::exportThemes() const
                 else {
                     qCritical() << "Can't copy " << sourceFileInfo.absoluteFilePath() << " to " << destinationFileInfo.absoluteFilePath();
                 }
+            }
+            else
+            {
+                if (destinationFileInfo.exists())
+                    qDebug() << destinationFileInfo.absoluteFilePath() << " exists in appFolder and will not be exported!";
+                else
+                    qDebug() << destinationFileInfo.absoluteFilePath() << " not exists, but will not be exported because the file in resources is not newer";
             }
         }
     }

--- a/src/Common/Configurator.cpp
+++ b/src/Common/Configurator.cpp
@@ -87,7 +87,7 @@ void Configurator::logHandler(QtMsgType type, const QMessageLogContext &context,
     }
     if (outFile.open(ioFlags)) {
         QTextStream ts(&outFile);
-        ts << stringMsg;
+        ts << stringMsg.replace(QRegularExpression("\\033\\[[0-6]{1,2}(;1)?m"), ""); // remove ANSI color codes from log file
     }
 
     if (type == QtFatalMsg)
@@ -199,10 +199,10 @@ void Configurator::exportThemes() const
 
             QFileInfo sourceFileInfo(pathInResources.absoluteFilePath(themeCSSFile));
             QFileInfo destinationFileInfo(destinationDir.absoluteFilePath(themeCSSFile));
-            //qDebug() << "source:" << jamTabaCompilationDate << " dest: " << destinationFileInfo.lastModified();
+
             if (!destinationFileInfo.exists() || jamTabaCompilationDate > destinationFileInfo.lastModified()) {
 
-                // QFile::copy can't replace existing files, so is necessary existing file before call QFile::copy
+                // QFile::copy can't replace existing files, so is necessary delete existing file before call QFile::copy
                 if (destinationFileInfo.exists())
                     QFile(destinationFileInfo.absoluteFilePath()).remove();
 

--- a/src/Common/Configurator.cpp
+++ b/src/Common/Configurator.cpp
@@ -173,9 +173,15 @@ void Configurator::exportThemes() const
     QDir resourceDir(THEMES_FOLDER_IN_RESOURCES);
     QDir themesDir = getThemesDir();
     QStringList themesInResources = resourceDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
-    QDateTime jamTabaCompilationDate = QDateTime::fromString(QString(__DATE__).simplified() + " " + QString(__TIME__).simplified(), "MMM d yyyy hh:mm:ss");
 
-    qDebug() << "Trying to export themes files JamTabaa compilationDate:" << jamTabaCompilationDate;
+    QDate compilationDate = QDate::fromString(QString(__DATE__).simplified(), "MMM d yyyy");
+    QTime compilationTime = QTime::fromString(QString(__TIME__).simplified(), "hh:mm:ss");
+    QDateTime jamTabaCompilationDate(compilationDate, compilationTime);
+
+    qDebug() << "Trying to export themes files JamTabaa compilationDateTime:" << jamTabaCompilationDate;
+    qDebug() << "C++ dateTime macros: " << "'" << __DATE__ << "'" << " " << "'" <<__TIME__ <<"'";
+    qDebug() << "compilation date: " << compilationDate;
+    qDebug() << "compilation time: " << compilationTime;
 
     for (const QString &themeDir : themesInResources) {
 

--- a/src/Common/Configurator.cpp
+++ b/src/Common/Configurator.cpp
@@ -174,7 +174,7 @@ void Configurator::exportThemes() const
     QDir themesDir = getThemesDir();
     QStringList themesInResources = resourceDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
-    QDate compilationDate = QDate::fromString(QString(__DATE__).simplified(), "MMM d yyyy");
+    QDate compilationDate = QLocale("en_US").toDate(QString(__DATE__).simplified(), "MMM d yyyy");   //QDate::fromString(QString(__DATE__).simplified(), "MMM d yyyy");
     QTime compilationTime = QTime::fromString(QString(__TIME__).simplified(), "hh:mm:ss");
     QDateTime jamTabaCompilationDate(compilationDate, compilationTime);
 

--- a/src/Common/Configurator.cpp
+++ b/src/Common/Configurator.cpp
@@ -174,14 +174,9 @@ void Configurator::exportThemes() const
     QDir themesDir = getThemesDir();
     QStringList themesInResources = resourceDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
 
-    QDate compilationDate = QLocale("en_US").toDate(QString(__DATE__).simplified(), "MMM d yyyy");   //QDate::fromString(QString(__DATE__).simplified(), "MMM d yyyy");
+    QDate compilationDate = QLocale("en_US").toDate(QString(__DATE__).simplified(), "MMM d yyyy");
     QTime compilationTime = QTime::fromString(QString(__TIME__).simplified(), "hh:mm:ss");
     QDateTime jamTabaCompilationDate(compilationDate, compilationTime);
-
-    qDebug() << "Trying to export themes files JamTabaa compilationDateTime:" << jamTabaCompilationDate;
-    qDebug() << "C++ dateTime macros: " << "'" << __DATE__ << "'" << " " << "'" <<__TIME__ <<"'";
-    qDebug() << "compilation date: " << compilationDate;
-    qDebug() << "compilation time: " << compilationTime;
 
     for (const QString &themeDir : themesInResources) {
 
@@ -217,13 +212,6 @@ void Configurator::exportThemes() const
                 else {
                     qCritical() << "Can't copy " << sourceFileInfo.absoluteFilePath() << " to " << destinationFileInfo.absoluteFilePath();
                 }
-            }
-            else
-            {
-                if (destinationFileInfo.exists())
-                    qDebug() << destinationFileInfo.absoluteFilePath() << " exists in appFolder and will not be exported!";
-                else
-                    qDebug() << destinationFileInfo.absoluteFilePath() << " not exists, but will not be exported because the file in resources is not newer";
             }
         }
     }

--- a/src/Common/Configurator.h
+++ b/src/Common/Configurator.h
@@ -65,12 +65,12 @@ private:
     void initializeDirs(); //this function is implemented in ConfiguratorStandalone.cpp and in ConfiguratorVST.cpp. Only the correct .cpp file is included in .pro files.
     void exportLogIniFile();
     void setupLogConfigFile();
-    bool needExportThemes() const;
+
     void exportThemes() const;
 
     static QDir getApplicationDataDir();
 
-    static void LogHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
+    static void logHandler(QtMsgType type, const QMessageLogContext &context, const QString &msg);
 
     static QString getDebugColor(const QMessageLogContext &context);
 };

--- a/src/Plugins/VST/main.cpp
+++ b/src/Plugins/VST/main.cpp
@@ -55,6 +55,7 @@ BOOL WINAPI DllMain(HINSTANCE hInst, DWORD dwReason, LPVOID /*lpvReserved*/)
             qCWarning(jtConfigurator) << "JTBConfig->setUp() FAILED !";
 
         ownApplication = QMfcApp::pluginInstance(hInst);
+
     }
     if (dwReason == DLL_PROCESS_DETACH && ownApplication)
         delete qApp;

--- a/src/Standalone/main.cpp
+++ b/src/Standalone/main.cpp
@@ -11,18 +11,18 @@
 
 int main(int argc, char* args[] ){
 
-    QApplication::setApplicationName("Jamtaba 2");
+    QApplication::setApplicationName("JamTaba 2");
     QApplication::setApplicationVersion(APP_VERSION);
 
-    //start the configurator
+    // start the configurator
     Configurator* configurator = Configurator::getInstance();
     if (!configurator->setUp())
-        qCWarning(jtConfigurator) << "JTBConfig->setUp() FAILED !" ;
+        qCritical() << "JTBConfig->setUp() FAILED !" ;
 
     Persistence::Settings settings;
     settings.load();
 
-//SingleApplication is not working in mac. Using a dirty ifdef until have time to solve the SingleApplication issue in Mac
+// SingleApplication is not working in mac. Using a dirty ifdef until have time to solve the SingleApplication issue in Mac
 #ifdef Q_OS_WIN
     QApplication* application = new SingleApplication(argc, args);
 #else
@@ -43,8 +43,8 @@ int main(int argc, char* args[] ){
     mainController.connectInJamtabaServer();
 
 #ifdef Q_OS_WIN
-    //The SingleApplication class implements a showUp() signal. You can bind to that signal to raise your application's
-    //window when a new instance had been started.
+    // The SingleApplication class implements a showUp() signal. You can bind to that signal to raise your application's
+    // window when a new instance had been started.
     QObject::connect(application, SIGNAL(showUp()), &mainWindow, SLOT(raise()));
 #endif
     int execResult = application->exec();


### PR DESCRIPTION
 - Trying to export every CSS theme file in resources folder when Jamtaba is started. A CSS file will be exported in 2 conditions:
	1 - if the file NOT exists in user appData folder OR
	2 - the file in resources folder is newer (checking the lastEdited atribute) then same file in user appData folder.