### PR TITLE
Black theme Color Peak meter and tab hover fix

### DIFF
--- a/src/resources/css/themes/Black_nm/General.css
+++ b/src/resources/css/themes/Black_nm/General.css
@@ -248,13 +248,6 @@ QTabBar::tab:selected
     background-color: rgb(20, 20, 20);
 }
 
-QTabBar::tab:hover,
-QTabBar::tab:hover:checked
-{
-    color: rgb(140, 140,140);
-    background-color: rgb(30, 30, 30);
-}
-
 QTabBar::tab:!selected
 {
     margin-top: 3px; /* make non-selected tabs look smaller */
@@ -264,7 +257,7 @@ QTabBar::tab:!selected
 
 QTabBar::tab:!selected:hover
 {
-    background-color: rgb(20, 20, 20);
+    background-color: rgb(30, 30, 30);
 }
 
 QMenuBar::item
@@ -322,7 +315,5 @@ AudioMeter
 {
     /* changing Audio Peak meter custom CSS properties */
     qproperty-rmsColor: rgb(110, 110, 110);
-    qproperty-peakStartColor: rgb(90, 90, 90);
-    qproperty-peakEndColor: white;
-    qproperty-maxPeakColor: rgb(240, 240, 240);
+    qproperty-maxPeakColor: rgb(110, 110, 110);
 }


### PR DESCRIPTION
I missed the nice green-yellow-red peak meter for the black theme. The gray meter was kept for the RMS only and the max peak meter is now a bit less bright to match the palette