### PR TITLE
[WIP] Allowing midi controlled audio tracks (like vocoders)

### DIFF
--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -263,7 +263,7 @@ void MainController::removeInputTrackNode(int inputTrackIndex)
     if (inputTracks.contains(inputTrackIndex)) {
         // remove from group
         Audio::LocalInputNode *inputTrack = inputTracks[inputTrackIndex];
-        int trackGroupIndex = inputTrack->getGroupChannelIndex();
+        int trackGroupIndex = inputTrack->getChanneGrouplIndex();
         if (trackGroups.contains(trackGroupIndex)) {
             trackGroups[trackGroupIndex]->removeInput(inputTrack);
             if (trackGroups[trackGroupIndex]->isEmpty())
@@ -281,12 +281,12 @@ int MainController::addInputTrackNode(Audio::LocalInputNode *inputTrackNode)
     inputTracks.insert(inputTrackID, inputTrackNode);
     addTrack(inputTrackID, inputTrackNode);
 
-    int trackGroupIndex = inputTrackNode->getGroupChannelIndex();
+    int trackGroupIndex = inputTrackNode->getChanneGrouplIndex();
     if (!trackGroups.contains(trackGroupIndex))
         trackGroups.insert(trackGroupIndex,
                            new Audio::LocalInputGroup(trackGroupIndex, inputTrackNode));
     else
-        trackGroups[trackGroupIndex]->addInput(inputTrackNode);
+        trackGroups[trackGroupIndex]->addInputNode(inputTrackNode);
 
     return inputTrackID;
 }
@@ -833,4 +833,13 @@ void MainController::storeMeteringSettings(bool showingMaxPeaks, quint8 meterOpt
 {
     settings.storeMeterOption(meterOption);
     settings.storeMeterShowingMaxPeaks(showingMaxPeaks);
+}
+
+Audio::LocalInputNode *MainController::getInputTrackInGroup(quint8 groupIndex, quint8 trackIndex) const
+{
+    Audio::LocalInputGroup *trackGroup = trackGroups[groupIndex];
+    if (!trackGroup)
+        return nullptr;
+
+    return trackGroup->getInputNode(trackIndex);
 }

--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -257,6 +257,13 @@ void MainController::saveEncodedAudio(const QString &userName, quint8 channelInd
 
 // +++++++++++++++++++++++++++++++++++++++++++++++
 
+void MainController::removeAllInputTracks()
+{
+    for(int trackID : inputTracks.keys()) {
+        removeInputTrackNode(trackID);
+    }
+}
+
 void MainController::removeInputTrackNode(int inputTrackIndex)
 {
     QMutexLocker locker(&mutex);

--- a/src/Common/MainController.h
+++ b/src/Common/MainController.h
@@ -170,6 +170,7 @@ public:
     Audio::LocalInputNode *getInputTrack(int localInputIndex);
     virtual int addInputTrackNode(Audio::LocalInputNode *inputTrackNode);
     void removeInputTrackNode(int inputTrackIndex);
+    void removeAllInputTracks();
 
     Audio::LocalInputNode *getInputTrackInGroup(quint8 groupIndex, quint8 trackIndex) const;
 

--- a/src/Common/MainController.h
+++ b/src/Common/MainController.h
@@ -171,6 +171,8 @@ public:
     virtual int addInputTrackNode(Audio::LocalInputNode *inputTrackNode);
     void removeInputTrackNode(int inputTrackIndex);
 
+    Audio::LocalInputNode *getInputTrackInGroup(quint8 groupIndex, quint8 trackIndex) const;
+
     inline int getInputTracksCount() const
     {
         return inputTracks.size();// return the individual tracks (subchannels) count

--- a/src/Common/audio/core/LocalInputGroup.cpp
+++ b/src/Common/audio/core/LocalInputGroup.cpp
@@ -7,7 +7,7 @@ LocalInputGroup::LocalInputGroup(int groupIndex, Audio::LocalInputNode *firstInp
     groupIndex(groupIndex),
     transmiting(true)
 {
-    addInput(firstInput);
+    addInputNode(firstInput);
 }
 
 LocalInputGroup::~LocalInputGroup()
@@ -15,10 +15,20 @@ LocalInputGroup::~LocalInputGroup()
     groupedInputs.clear();
 }
 
-void LocalInputGroup::addInput(Audio::LocalInputNode *input)
+void LocalInputGroup::addInputNode(Audio::LocalInputNode *input)
 {
     groupedInputs.append(input);
 }
+
+LocalInputNode *LocalInputGroup::getInputNode(quint8 index) const
+{
+    if (index < groupedInputs.size()) {
+        return groupedInputs.at(index);
+    }
+
+    return nullptr;
+}
+
 
 void LocalInputGroup::mixGroupedInputs(Audio::SamplesBuffer &out)
 {

--- a/src/Common/audio/core/LocalInputGroup.h
+++ b/src/Common/audio/core/LocalInputGroup.h
@@ -14,17 +14,11 @@ public:
     LocalInputGroup(int groupIndex, Audio::LocalInputNode *firstInput);
     ~LocalInputGroup();
 
-    inline bool isEmpty() const
-    {
-        return groupedInputs.empty();
-    }
+    bool isEmpty() const;
 
-    void addInput(Audio::LocalInputNode *input);
+    void addInputNode(Audio::LocalInputNode *input);
 
-    inline int getIndex() const
-    {
-        return groupIndex;
-    }
+    int getIndex() const;
 
     void mixGroupedInputs(Audio::SamplesBuffer &out);
 
@@ -32,18 +26,32 @@ public:
 
     int getMaxInputChannelsForEncoding() const;
 
-    inline bool isTransmiting() const
-    {
-        return transmiting;
-    }
+    bool isTransmiting() const;
 
     void setTransmitingStatus(bool transmiting);
+
+    Audio::LocalInputNode *getInputNode(quint8 index) const;
 
 private:
     int groupIndex;
     QList<Audio::LocalInputNode *> groupedInputs;
     bool transmiting;
 };
+
+inline bool LocalInputGroup::isTransmiting() const
+{
+    return transmiting;
+}
+
+inline int LocalInputGroup::getIndex() const
+{
+    return groupIndex;
+}
+
+inline bool LocalInputGroup::isEmpty() const
+{
+    return groupedInputs.empty();
+}
 
 }//namespace
 

--- a/src/Common/audio/core/LocalInputNode.cpp
+++ b/src/Common/audio/core/LocalInputNode.cpp
@@ -217,6 +217,10 @@ void LocalInputNode::processReplacing(const SamplesBuffer &in, SamplesBuffer &ou
                 processMidiInput(midiBuffer, filteredMidiBuffer);
         }
         else if (isMidi()) {
+
+            if (isRoutingMidiInput())
+                return; // when routing midi this track will not render midi data, this data will be rendered by first subchannel
+
             processMidiInput(midiBuffer, filteredMidiBuffer);
         }
     }

--- a/src/Common/audio/core/LocalInputNode.cpp
+++ b/src/Common/audio/core/LocalInputNode.cpp
@@ -217,13 +217,12 @@ void LocalInputNode::processReplacing(const SamplesBuffer &in, SamplesBuffer &ou
                 processMidiInput(midiBuffer, filteredMidiBuffer);
         }
         else if (isMidi()) {
-
-            if (isRoutingMidiInput())
-                return; // when routing midi this track will not render midi data, this data will be rendered by first subchannel
-
             processMidiInput(midiBuffer, filteredMidiBuffer);
         }
     }
+
+    if (isRoutingMidiInput())
+        return; // when routing midi this track will not render midi data, this data will be rendered by first subchannel. But the midi data is processed above to update MIDI activity meter
 
     AudioNode::processReplacing(in, out, sampleRate, filteredMidiBuffer);
 }

--- a/src/Common/audio/core/LocalInputNode.cpp
+++ b/src/Common/audio/core/LocalInputNode.cpp
@@ -221,8 +221,11 @@ void LocalInputNode::processReplacing(const SamplesBuffer &in, SamplesBuffer &ou
         }
     }
 
-    if (isRoutingMidiInput())
+    if (isRoutingMidiInput()) {
+        lastPeak.update(AudioPeak()); // ensure the audio meters will be ZERO
+
         return; // when routing midi this track will not render midi data, this data will be rendered by first subchannel. But the midi data is processed above to update MIDI activity meter
+    }
 
     AudioNode::processReplacing(in, out, sampleRate, filteredMidiBuffer);
 }

--- a/src/Common/audio/core/LocalInputNode.cpp
+++ b/src/Common/audio/core/LocalInputNode.cpp
@@ -89,6 +89,7 @@ LocalInputNode::LocalInputNode(Controller::MainController *mainController, int p
 
 LocalInputNode::~LocalInputNode()
 {
+    //
 }
 
 bool LocalInputNode::isMono() const
@@ -227,6 +228,10 @@ void LocalInputNode::setRoutingMidiInput(bool routeMidiInput)
 {
     quint8 subchannelIndex = 0; // first subchannel
     LocalInputNode *firstSubchannel = mainController->getInputTrackInGroup(channelGroupIndex, subchannelIndex);
+
+    if (firstSubchannel == this)
+        return; //midi routing is not allows in first subchannel
+
     if (firstSubchannel) {
         routingMidiInput = routeMidiInput;
 

--- a/src/Common/audio/core/LocalInputNode.cpp
+++ b/src/Common/audio/core/LocalInputNode.cpp
@@ -365,5 +365,6 @@ void LocalInputNode::reset()
     setToNoInput();
 
     stereoInverted = false;
+
     emit stereoInversionChanged(stereoInverted);
 }

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -291,6 +291,7 @@ Persistence::LocalInputTrackSettings MainWindow::getInputsSettings() const
     LocalInputTrackSettings settings;
     foreach (LocalTrackGroupView *trackGroupView, localGroupChannels) {
         Channel channel(trackGroupView->getGroupName());
+        int subchannelsCount = 0;
         foreach (LocalTrackView *trackView, trackGroupView->getTracks<LocalTrackView *>()) {
             LocalInputNode *inputNode = trackView->getInputNode();
             ChannelRange inputNodeRange = inputNode->getAudioInputRange();
@@ -306,10 +307,13 @@ Persistence::LocalInputTrackSettings MainWindow::getInputsSettings() const
             qint8 transpose = inputNode->getTranspose();
             quint8 lowerNote = inputNode->getMidiLowerNote();
             quint8 higherNote = inputNode->getMidiHigherNote();
+            bool routindMidiInput = subchannelsCount > 0 && inputNode->isRoutingMidiInput(); // midi routing is not allowed in first subchannel
 
             Subchannel sub(firstInput, channels, midiDevice, midiChannel, gain, boost, pan, muted, stereoInverted,
-                           transpose, lowerNote, higherNote);
+                                                                    transpose, lowerNote, higherNote, routindMidiInput);
             channel.subChannels.append(sub);
+
+            subchannelsCount++;
         }
         settings.channels.append(channel);
     }

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -467,6 +467,8 @@ void MainWindow::loadPreset(const Preset &preset)
 
 void MainWindow::removeAllInputLocalTracks()
 {
+    mainController->removeAllInputTracks();
+
     while (!localGroupChannels.isEmpty()) {
         LocalTrackGroupView *view = localGroupChannels.first();
         ui.localTracksLayout->removeWidget(view);

--- a/src/Common/gui/widgets/PeakMeter.h
+++ b/src/Common/gui/widgets/PeakMeter.h
@@ -15,9 +15,14 @@ public:
     QSize minimumSizeHint() const override;
 
 protected:
-    inline bool isVertical() const { return orientation == Qt::Vertical; }
 
-    QRectF getPaintRect(float peakValue) const;
+    virtual void recreateInterpolatedColors() = 0;
+
+    void resizeEvent(QResizeEvent *) override;
+
+    void paintSegments(QPainter &painter, float rawPeakValue, const std::vector<QColor> &segmentsColors, int offset = 0, bool halfSize = false);
+
+    inline bool isVertical() const { return orientation == Qt::Vertical; }
 
     static float limitFloatValue(float value, float minValue = 0.0f, float maxValue = 1.0f);
 
@@ -26,6 +31,8 @@ protected:
     int decayTime;
 
     Qt::Orientation orientation;
+
+    static const quint8 SEGMENTS_SIZE;
 
     static const int LINES_MARGIN;
     static const int MIN_SIZE;
@@ -69,7 +76,8 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *event) override;
-    void resizeEvent(QResizeEvent *) override;
+
+    void recreateInterpolatedColors() override;
 
 private:
     static const int MAX_PEAK_SHOW_TIME;
@@ -94,19 +102,14 @@ private:
 
     qint64 lastMaxPeakTime;
 
-    static const quint8 segmentsSize;
-
-    void paintSegments(QPainter &painter, float rawPeakValue, const std::vector<QColor> &segmentsColors, int offset, bool halfSize);
-
     void paintMaxPeakMarker(QPainter &painter, bool halfSize);
 
     void updateInternalValues();
 
     QColor interpolateColor(const QColor &start, const QColor &end, float ratio);
 
-    void recreateInterpolatedColors();
-
 };
+
 
 class MidiActivityMeter : public BaseMeter
 {
@@ -117,10 +120,13 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *event) override;
-
+    void recreateInterpolatedColors() override;
 private:
-    QColor solidColor;
+    QColor midiActivityColor;
+    std::vector<QColor> colors;
     float activityValue;
+
+    void updateInternalValues();
 };
 
 #endif

--- a/src/Common/midi/MidiMessage.cpp
+++ b/src/Common/midi/MidiMessage.cpp
@@ -46,7 +46,7 @@ MidiMessage MidiMessage::fromArray(const char array[4], qint32 deviceIndex)
 
 void MidiMessage::transpose(qint8 semitones)
 {
-    if (!isNote()) {
+    if (!isNote() || semitones == 0) {
         return;
     }
     quint32 newValue = data + (semitones << 8);

--- a/src/Common/midi/MidiMessage.h
+++ b/src/Common/midi/MidiMessage.h
@@ -26,7 +26,7 @@ public:
 
     quint8 getNoteVelocity() const;
 
-    int getSourceID() const;
+    int getSourceDeviceIndex() const;
 
     int getStatus() const;
 
@@ -46,7 +46,7 @@ inline int MidiMessage::getChannel() const
     return data & 0x0000000F;
 }
 
-inline int MidiMessage::getSourceID() const
+inline int MidiMessage::getSourceDeviceIndex() const
 {
     return sourceID;
 }

--- a/src/Common/persistence/Settings.h
+++ b/src/Common/persistence/Settings.h
@@ -173,7 +173,7 @@ class Subchannel
 {
 public:
     Subchannel(int firstInput, int channelsCount, int midiDevice, int midiChannel, float gain,
-               int boost, float pan, bool muted, bool stereoInverted, qint8 transpose, quint8 lowerMidiNote, quint8 higherMidiNote);
+               int boost, float pan, bool muted, bool stereoInverted, qint8 transpose, quint8 lowerMidiNote, quint8 higherMidiNote, bool routingMidiToFirstSubchannel);
     int firstInput;
     int channelsCount;
     int midiDevice;
@@ -186,6 +186,7 @@ public:
     qint8 transpose; //midi transpose
     quint8 lowerMidiNote; //midi rey range
     quint8 higherMidiNote;
+    bool routingMidiToFirstSubchannel;
 
     inline QList<Persistence::Plugin> getPlugins() const
     {
@@ -240,7 +241,7 @@ public:
     LocalInputTrackSettings(bool createOneTrack = false);
     void write(QJsonObject &out) const override;
     void read(const QJsonObject &in) override;
-    void read(const QJsonObject &in, bool allowMultiSubchannels);
+    void read(const QJsonObject &in, bool allowSubchannels);
     QList<Channel> channels;
 
     static Plugin jsonObjectToPlugin(QJsonObject jsonObject);

--- a/src/Standalone/MainControllerStandalone.cpp
+++ b/src/Standalone/MainControllerStandalone.cpp
@@ -63,7 +63,7 @@
             }
             if (isPlayingInNinjamRoom()) {
                 if (ninjamController)// just in case
-                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getGroupChannelIndex());
+                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getChanneGrouplIndex());
 
             }
         }
@@ -183,7 +183,7 @@
                 window->refreshTrackInputSelection(localChannelIndex);
             if (isPlayingInNinjamRoom()) {
                 if (ninjamController)
-                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getGroupChannelIndex());
+                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getChanneGrouplIndex());
 
             }
         }
@@ -202,7 +202,7 @@
                         intervalsToUpload[localChannelIndex]->getGUID(), QByteArray(), true);
                     if (ninjamController)
                         ninjamController->scheduleEncoderChangeForChannel(
-                            inputTrack->getGroupChannelIndex());
+                            inputTrack->getChanneGrouplIndex());
                 }
             }
         }
@@ -229,7 +229,7 @@
                 window->refreshTrackInputSelection(localChannelIndex);
             if (isPlayingInNinjamRoom()) {
                 if (ninjamController)
-                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getGroupChannelIndex());
+                    ninjamController->scheduleEncoderChangeForChannel(inputTrack->getChanneGrouplIndex());
 
             }
         }

--- a/src/Standalone/gui/FxPanelItem.cpp
+++ b/src/Standalone/gui/FxPanelItem.cpp
@@ -92,6 +92,9 @@ void FxPanelItem::unsetPlugin()
 
 void FxPanelItem::mousePressEvent(QMouseEvent *event)
 {
+    if (!isEnabled())
+        return;
+
     if (event->button() == Qt::LeftButton) {
         if (!containPlugin()) {
             on_contextMenu(event->pos());
@@ -104,12 +107,18 @@ void FxPanelItem::mousePressEvent(QMouseEvent *event)
 
 void FxPanelItem::enterEvent(QEvent *)
 {
+    if (!isEnabled())
+        return;
+
     if (!containPlugin())
         label->setText(tr("new effect..."));
 }
 
 void FxPanelItem::leaveEvent(QEvent *)
 {
+    if (!isEnabled())
+        return;
+
     if (!containPlugin())
         label->setText("");
 }

--- a/src/Standalone/gui/FxPanelItem.h
+++ b/src/Standalone/gui/FxPanelItem.h
@@ -41,9 +41,9 @@ public:
     Q_PROPERTY(bool containPlugin READ containPlugin())// to use in stylesheet
 
 protected:
-    void mousePressEvent(QMouseEvent *event);
-    void enterEvent(QEvent *);
-    void leaveEvent(QEvent *);
+    void mousePressEvent(QMouseEvent *event) override;
+    void enterEvent(QEvent *) override;
+    void leaveEvent(QEvent *) override;
 
 private slots:
     void on_contextMenu(QPoint p);

--- a/src/Standalone/gui/LocalTrackGroupViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackGroupViewStandalone.cpp
@@ -32,9 +32,22 @@ void LocalTrackGroupViewStandalone::createSubChannelActions(QMenu &menu)
 }
 
 //overrided factory method
-LocalTrackViewStandalone* LocalTrackGroupViewStandalone::createTrackView(long trackID){
+LocalTrackViewStandalone* LocalTrackGroupViewStandalone::createTrackView(long trackID)
+{
     MainControllerStandalone* controller = dynamic_cast<MainWindowStandalone *>(mainFrame)->getMainController();
-    return new LocalTrackViewStandalone( controller, trackID );
+
+    LocalTrackViewStandalone *trackView = new LocalTrackViewStandalone(controller, trackID );
+
+    connect(trackView, &LocalTrackViewStandalone::trackInputChanged, this, &LocalTrackGroupViewStandalone::repaintLocalTracks);
+
+    return trackView;
+}
+
+void LocalTrackGroupViewStandalone::repaintLocalTracks()
+{
+    for (BaseTrackView *trackView : this->trackViews) {
+        trackView->update();
+    }
 }
 
 LocalTrackViewStandalone *LocalTrackGroupViewStandalone::addTrackView(long trackID)

--- a/src/Standalone/gui/LocalTrackGroupViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackGroupViewStandalone.h
@@ -26,6 +26,9 @@ protected:
 private:
     void createSubChannelActions(QMenu &menu);
 
+private slots:
+     void repaintLocalTracks();
+
 };
 
 #endif

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -615,7 +615,12 @@ QMenu *LocalTrackViewStandalone::createMidiInputsMenu(QMenu *parent)
 void LocalTrackViewStandalone::setToNoInput()
 {
     if (inputNode) {
+
+        if (inputNode->isRoutingMidiInput())
+            setMidiRouting(false);
+
         inputNode->setToNoInput();
+
         refreshInputSelectionName();
 
         emit trackInputChanged();
@@ -765,6 +770,9 @@ void LocalTrackViewStandalone::setMidiPeakMeterVisibility(bool visible)
 
 void LocalTrackViewStandalone::setToMono(QAction *action)
 {
+    if (inputNode->isRoutingMidiInput())
+        setMidiRouting(false);
+
     int selectedInputIndexInAudioDevice = action->data().toInt();
     controller->setInputTrackToMono(getTrackID(), selectedInputIndexInAudioDevice);
     setMidiPeakMeterVisibility(false);
@@ -774,6 +782,9 @@ void LocalTrackViewStandalone::setToMono(QAction *action)
 
 void LocalTrackViewStandalone::setToStereo(QAction *action)
 {
+    if (inputNode->isRoutingMidiInput())
+        setMidiRouting(false);
+
     int firstInputIndexInAudioDevice = action->data().toInt();
     controller->setInputTrackToStereo(getTrackID(), firstInputIndexInAudioDevice);
     setMidiPeakMeterVisibility(false);

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -230,14 +230,28 @@ QPushButton *LocalTrackViewStandalone::createMidiToolsButton()
     return button;
 }
 
+void LocalTrackViewStandalone::setAudioRelatedControlsStatus(bool enableControls)
+{
+    QWidget *controls[] = {
+        buttonBoostMinus12, buttonBoostPlus12, buttonBoostZero,
+        soloButton, muteButton, buttonStereoInversion,
+        panSlider, levelSlider
+    };
+
+    for (QWidget *control: controls) {
+        control->setEnabled(enableControls);
+    }
+
+    fxPanel->setEnabled(enableControls);
+
+}
+
 void LocalTrackViewStandalone::setMidiRouting(bool routingMidiToFirstSubchannel)
 {
     inputNode->setRoutingMidiInput(routingMidiToFirstSubchannel);
 
-    QPushButton *buttons[] = { buttonStereoInversion, buttonBoostMinus12, buttonBoostPlus12, buttonBoostZero, soloButton, muteButton };
-    for (QPushButton *button : buttons) {
-        button->setEnabled(!routingMidiToFirstSubchannel);
-    }
+    bool enableAudioControls = !routingMidiToFirstSubchannel;
+    setAudioRelatedControlsStatus(enableAudioControls);
 
     update();
 }

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -227,7 +227,7 @@ QPushButton *LocalTrackViewStandalone::createMidiToolsButton()
     return button;
 }
 
-void LocalTrackViewStandalone::changeMidiRoutingStatus(bool routingMidiToFirstSubchannel)
+void LocalTrackViewStandalone::setMidiRouting(bool routingMidiToFirstSubchannel)
 {
     inputNode->setRoutingMidiInput(routingMidiToFirstSubchannel);
 
@@ -265,7 +265,7 @@ void LocalTrackViewStandalone::openMidiToolsDialog()
         connect(midiToolsDialog, &MidiToolsDialog::higherNoteChanged, this, &LocalTrackViewStandalone::setMidiHigherNote);
         connect(midiToolsDialog, &MidiToolsDialog::transposeChanged, this, &LocalTrackViewStandalone::setTranspose);
         connect(midiToolsDialog, &MidiToolsDialog::learnMidiNoteClicked, this, &LocalTrackViewStandalone::toggleMidiNoteLearn);
-        connect(midiToolsDialog, &MidiToolsDialog::midiRoutingCheckBoxClicked, this, &LocalTrackViewStandalone::changeMidiRoutingStatus);
+        connect(midiToolsDialog, &MidiToolsDialog::midiRoutingCheckBoxClicked, this, &LocalTrackViewStandalone::setMidiRouting);
     }
 
     QRect desktopRect = QApplication::desktop()->availableGeometry();

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -79,9 +79,8 @@ void LocalTrackViewStandalone::paintRoutingMidiArrow(const QColor &color, int to
 
     // draw MIDI word
     QString text("MIDI");
-    int textWidth = fontMetrics().width(text);
-    int textX = metersCenter/2 - textWidth/2;
-    painter.drawText(textX, y-1, "MIDI");
+    int textX = leftMargin + arrowSize + 2;
+    painter.drawText(textX, y + fontMetrics().height() - 2, text);
 
     // draw arrow in left side
     QPainterPath arrow(QPointF(leftMargin, y+1));
@@ -130,7 +129,7 @@ void LocalTrackViewStandalone::paintEvent(QPaintEvent *ev)
     LocalTrackView::paintEvent(ev);
 
     static const QColor redColor(255, 0, 0, 100);
-    static const int topMargin = 7;
+    static const int topMargin = 4;
     static const int arrowSize = 4;
 
     if (inputNode->isRoutingMidiInput()) {

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -51,7 +51,7 @@ LocalTrackViewStandalone::LocalTrackViewStandalone(
     translateUI();
 }
 
-void LocalTrackViewStandalone::paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine)
+void LocalTrackViewStandalone::paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine, bool drawMidiWord)
 {
     QPainter painter(this);
 
@@ -78,10 +78,14 @@ void LocalTrackViewStandalone::paintRoutingMidiArrow(const QColor &color, int to
     y = topMargin;
     painter.drawLine(x-1, y, leftMargin + arrowSize, y);
 
-    // draw MIDI word
-    QString text("MIDI");
-    int textX = leftMargin + arrowSize + 2;
-    painter.drawText(textX, y + fontMetrics().height() - 2, text);
+    if (drawMidiWord) { // the MIDI word is not drawd when local tracks are collapsed
+        // draw MIDI word
+        QString text("MIDI");
+        static const QFont smallFont(font().family(), 5);
+        setFont(smallFont);
+        int textX = leftMargin + arrowSize + 2;
+        painter.drawText(textX, y + fontMetrics().height(), text);
+    }
 
     // draw arrow in left side
     QPainterPath arrow(QPointF(leftMargin, y+1));
@@ -92,8 +96,6 @@ void LocalTrackViewStandalone::paintRoutingMidiArrow(const QColor &color, int to
     painter.setBrush(color);
     painter.setPen(Qt::NoPen);
     painter.drawPath(arrow);
-
-
 }
 
 void LocalTrackViewStandalone::paintReceivingRoutedMidiIndicator(const QColor &color, int topMargin, int arrowSize)
@@ -120,7 +122,7 @@ void LocalTrackViewStandalone::paintReceivingRoutedMidiIndicator(const QColor &c
     x2 = width() - rightMargin - arrowSize;
     painter.drawLine(x+1, y, x2, y);
 
-    x2++;
+    x2 += 2;
     painter.drawLine(x2,     y - arrowSize, x2,     y + arrowSize);
     painter.drawLine(x2 + 1, y - arrowSize, x2 + 1, y + arrowSize);
 }
@@ -129,13 +131,14 @@ void LocalTrackViewStandalone::paintEvent(QPaintEvent *ev)
 {
     LocalTrackView::paintEvent(ev);
 
-    static const int topMargin = 4;
+    const int topMargin = isShowingPeakMetersOnly() ? 5 : 4;
     static const int arrowSize = 4;
 
     if (inputNode->isRoutingMidiInput()) {
         Audio::LocalInputNode *firstSubchannel = mainController->getInputTrackInGroup(inputNode->getChanneGrouplIndex(), 0);
         bool drawSolidLine = firstSubchannel && firstSubchannel->isReceivingRoutedMidiInput();
-        paintRoutingMidiArrow(midiRoutingArrowColor, topMargin, arrowSize, drawSolidLine);
+        bool drawMidiWord = !isShowingPeakMetersOnly();
+        paintRoutingMidiArrow(midiRoutingArrowColor, topMargin, arrowSize, drawSolidLine, drawMidiWord);
     }
 
     if (inputNode->isReceivingRoutedMidiInput())

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -239,6 +239,13 @@ void LocalTrackViewStandalone::changeMidiRoutingStatus(bool routingMidiToFirstSu
     update();
 }
 
+bool LocalTrackViewStandalone::isFirstSubchannel() const
+{
+    Audio::LocalInputNode *firstSubchannel = mainController->getInputTrackInGroup(inputNode->getChanneGrouplIndex(), 0);
+
+    return firstSubchannel == this->inputNode;
+}
+
 void LocalTrackViewStandalone::openMidiToolsDialog()
 {
     if (!midiToolsDialog) {
@@ -248,7 +255,11 @@ void LocalTrackViewStandalone::openMidiToolsDialog()
         QString lowerNote = getMidiNoteText(inputNode->getMidiLowerNote());
         qint8 transpose = inputNode->getTranspose();
         bool routingMidiInput = inputNode->isRoutingMidiInput();
+
         midiToolsDialog = new MidiToolsDialog(lowerNote, higherNote, transpose, routingMidiInput);
+        if (isFirstSubchannel())
+            midiToolsDialog->hideMidiRoutingControls(); // midi routing is available only in second subchannel
+
         connect(midiToolsDialog, &MidiToolsDialog::dialogClosed, this, &LocalTrackViewStandalone::onMidiToolsDialogClosed);
         connect(midiToolsDialog, &MidiToolsDialog::lowerNoteChanged, this, &LocalTrackViewStandalone::setMidiLowerNote);
         connect(midiToolsDialog, &MidiToolsDialog::higherNoteChanged, this, &LocalTrackViewStandalone::setMidiHigherNote);
@@ -719,12 +730,12 @@ void LocalTrackViewStandalone::updateInputText()
     inputSelectionButton->setText(elidedName);
 }
 
-bool LocalTrackViewStandalone::canShowInputTypeIcon()
+bool LocalTrackViewStandalone::canShowInputTypeIcon() const
 {
     return !inputNode->isMidi() && !isShowingPeakMetersOnly();
 }
 
-bool LocalTrackViewStandalone::canShowMidiToolsButton()
+bool LocalTrackViewStandalone::canShowMidiToolsButton() const
 {
     return inputNode->isMidi() && !isShowingPeakMetersOnly();
 }

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -231,6 +231,12 @@ QPushButton *LocalTrackViewStandalone::createMidiToolsButton()
 void LocalTrackViewStandalone::changeMidiRoutingStatus(bool routingMidiToFirstSubchannel)
 {
     inputNode->setRoutingMidiInput(routingMidiToFirstSubchannel);
+
+    QPushButton *buttons[] = { buttonStereoInversion, buttonBoostMinus12, buttonBoostPlus12, buttonBoostZero, soloButton, muteButton };
+    for (QPushButton *button : buttons) {
+        button->setEnabled(!routingMidiToFirstSubchannel);
+    }
+
     update();
 }
 

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -180,8 +180,11 @@ void LocalTrackViewStandalone::updateGuiElements()
 void LocalTrackViewStandalone::reset()
 {
     LocalTrackView::reset();
+
     if (fxPanel)
         fxPanel->removePlugins();
+
+    setMidiRouting(false);
 }
 
 QLabel *LocalTrackViewStandalone::createInputTypeIconLabel(QWidget *parent)

--- a/src/Standalone/gui/LocalTrackViewStandalone.cpp
+++ b/src/Standalone/gui/LocalTrackViewStandalone.cpp
@@ -16,7 +16,8 @@ LocalTrackViewStandalone::LocalTrackViewStandalone(
     Controller::MainControllerStandalone *mainController, int channelIndex) :
     LocalTrackView(mainController, channelIndex),
     controller(mainController),
-    midiToolsDialog(nullptr)
+    midiToolsDialog(nullptr),
+    midiRoutingArrowColor(QColor(255, 0, 0, 100))
 {
     fxPanel = createFxPanel();
 
@@ -128,18 +129,17 @@ void LocalTrackViewStandalone::paintEvent(QPaintEvent *ev)
 {
     LocalTrackView::paintEvent(ev);
 
-    static const QColor redColor(255, 0, 0, 100);
     static const int topMargin = 4;
     static const int arrowSize = 4;
 
     if (inputNode->isRoutingMidiInput()) {
         Audio::LocalInputNode *firstSubchannel = mainController->getInputTrackInGroup(inputNode->getChanneGrouplIndex(), 0);
         bool drawSolidLine = firstSubchannel && firstSubchannel->isReceivingRoutedMidiInput();
-        paintRoutingMidiArrow(redColor, topMargin, arrowSize, drawSolidLine);
+        paintRoutingMidiArrow(midiRoutingArrowColor, topMargin, arrowSize, drawSolidLine);
     }
 
     if (inputNode->isReceivingRoutedMidiInput())
-        paintReceivingRoutedMidiIndicator(redColor, topMargin, arrowSize);
+        paintReceivingRoutedMidiIndicator(midiRoutingArrowColor, topMargin, arrowSize);
 }
 
 void LocalTrackViewStandalone::translateUI()

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -118,7 +118,7 @@ private:
     QString getInputTypeIconFile();
     bool canUseMidiDeviceIndex(int midiDeviceIndex) const;
 
-    void paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine);
+    void paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine, bool drawMidiWord);
     void paintReceivingRoutedMidiIndicator(const QColor &color, int topMargin, int arrowSize);
 
     MidiToolsDialog *midiToolsDialog;

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -121,6 +121,8 @@ private:
     void paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine, bool drawMidiWord);
     void paintReceivingRoutedMidiIndicator(const QColor &color, int topMargin, int arrowSize);
 
+    void setAudioRelatedControlsStatus(bool enableControls);
+
     MidiToolsDialog *midiToolsDialog;
 
     QColor midiRoutingArrowColor;

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -39,20 +39,22 @@ public:
 
     void refreshInputSelectionName();
 
+signals:
+    void trackInputChanged();
+
 public slots:
     void setToNoInput();
+
+protected:
+    void paintEvent(QPaintEvent *ev) override;
+    void translateUI() override;
+    bool eventFilter(QObject *target, QEvent *event) override;
+    void setupMetersLayout() override;
 
 protected slots:
     void setToMono(QAction *action) ;
     void setToStereo(QAction *action) ;
     void setToMidi(QAction *action) ;
-
-protected:
-    void translateUI() override;
-
-    bool eventFilter(QObject *target, QEvent *event) override;
-
-    void setupMetersLayout() override;
 
 private slots:
     void showInputSelectionMenu();// build and show the input selection menu
@@ -66,8 +68,10 @@ private slots:
     void toggleMidiNoteLearn(bool);
 
     void useLearnedMidiNote(quint8 midiNote);
-private:
 
+    void changeMidiRoutingStatus(bool routingMidiToFirstSubchannel);
+
+private:
     Controller::MainControllerStandalone* controller;//a 'casted' pointer just for convenience
 
     QMenu *createMonoInputsMenu(QMenu *parentMenu);
@@ -109,6 +113,9 @@ private:
     QString getMidiInputText();
     QString getInputTypeIconFile();
     bool canUseMidiDeviceIndex(int midiDeviceIndex) const;
+
+    void paintRoutingMidiArrow(const QColor &color, int topMargin, int arrowSize, bool drawSolidLine);
+    void paintReceivingRoutedMidiIndicator(const QColor &color, int topMargin, int arrowSize);
 
     MidiToolsDialog *midiToolsDialog;
 

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -15,6 +15,9 @@ class LocalTrackViewStandalone : public LocalTrackView
 {
     Q_OBJECT
 
+    // custom properties defined in CSS files
+    Q_PROPERTY(QColor midiRoutingArrowColor MEMBER midiRoutingArrowColor)
+
 public:
 
     LocalTrackViewStandalone(Controller::MainControllerStandalone* mainController, int channelID);
@@ -118,6 +121,8 @@ private:
     void paintReceivingRoutedMidiIndicator(const QColor &color, int topMargin, int arrowSize);
 
     MidiToolsDialog *midiToolsDialog;
+
+    QColor midiRoutingArrowColor;
 
     static const QString MIDI_ICON;
     static const QString MONO_ICON;

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -47,6 +47,7 @@ signals:
 
 public slots:
     void setToNoInput();
+    void setMidiRouting(bool routingMidiToFirstSubchannel);
 
 protected:
     void paintEvent(QPaintEvent *ev) override;
@@ -71,8 +72,6 @@ private slots:
     void toggleMidiNoteLearn(bool);
 
     void useLearnedMidiNote(quint8 midiNote);
-
-    void changeMidiRoutingStatus(bool routingMidiToFirstSubchannel);
 
 private:
     Controller::MainControllerStandalone* controller;//a 'casted' pointer just for convenience

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -105,8 +105,10 @@ private:
     void startMidiNoteLearn();
     void stopMidiNoteLearn();
 
-    bool canShowMidiToolsButton();
-    bool canShowInputTypeIcon();
+    bool canShowMidiToolsButton() const;
+    bool canShowInputTypeIcon() const;
+
+    bool isFirstSubchannel() const;
 
     void updateInputText();
     void updateInputIcon();

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -238,11 +238,13 @@ void MainWindowStandalone::initializeLocalSubChannel(LocalTrackView *subChannelV
     // load channels names, gain, pan, boost, mute
     MainWindow::initializeLocalSubChannel(subChannelView, subChannel);
 
+    auto trackView = dynamic_cast<LocalTrackViewStandalone *>(subChannelView);
+    trackView->setMidiRouting(subChannel.routingMidiToFirstSubchannel);
+
     // check if the loaded input selections (midi, audio mono, audio stereo) are stil valid and fallback if not
     sanitizeSubchannelInputSelections(subChannelView, subChannel);
 
-    restoreLocalSubchannelPluginsList(dynamic_cast<LocalTrackViewStandalone *>(subChannelView),
-                                      subChannel);
+    restoreLocalSubchannelPluginsList(trackView, subChannel);
 }
 
 LocalTrackGroupViewStandalone *MainWindowStandalone::createLocalTrackGroupView(int channelGroupIndex)
@@ -268,8 +270,7 @@ LocalInputTrackSettings MainWindowStandalone::getInputsSettings() const
 
     // recreate the settings including the plugins
     LocalInputTrackSettings settings;
-    QList<LocalTrackGroupViewStandalone *> groups
-        = getLocalChannels<LocalTrackGroupViewStandalone *>();
+    QList<LocalTrackGroupViewStandalone *> groups = getLocalChannels<LocalTrackGroupViewStandalone *>();
     Q_ASSERT(groups.size() == baseSettings.channels.size());
 
     int channelID = 0;
@@ -280,8 +281,7 @@ LocalInputTrackSettings MainWindowStandalone::getInputsSettings() const
         Channel newChannel = channel;
         newChannel.subChannels.clear();
         int subChannelID = 0;
-        QList<LocalTrackViewStandalone *> trackViews
-            = trackGroupView->getTracks<LocalTrackViewStandalone *>();
+        QList<LocalTrackViewStandalone *> trackViews = trackGroupView->getTracks<LocalTrackViewStandalone *>();
         foreach (Subchannel subchannel, channel.subChannels) {
             Subchannel newSubChannel = subchannel;
             LocalTrackViewStandalone *trackView = trackViews.at(subChannelID);

--- a/src/Standalone/gui/MainWindowStandalone.h
+++ b/src/Standalone/gui/MainWindowStandalone.h
@@ -56,9 +56,7 @@ protected slots: //TODO change to private slots?
 
 private slots:
     void toggleFullScreen();
-
     void closePluginScanDialog();
-
     void restartAudioAndMidi();
 
 private:

--- a/src/Standalone/gui/MidiToolsDialog.cpp
+++ b/src/Standalone/gui/MidiToolsDialog.cpp
@@ -35,6 +35,11 @@ MidiToolsDialog::MidiToolsDialog(const QString &lowerNote, const QString &higher
     connect(ui->checkBoxMidiRouting, &QCheckBox::toggled, this, &MidiToolsDialog::midiRoutingCheckBoxClicked);
 }
 
+void MidiToolsDialog::hideMidiRoutingControls()
+{
+    ui->checkBoxMidiRouting->hide();
+}
+
 MidiToolsDialog::~MidiToolsDialog()
 {
     delete ui;

--- a/src/Standalone/gui/MidiToolsDialog.cpp
+++ b/src/Standalone/gui/MidiToolsDialog.cpp
@@ -4,7 +4,7 @@
 
 #include "LocalTrackViewStandalone.h"
 
-MidiToolsDialog::MidiToolsDialog(const QString &lowerNote, const QString &higherNote, qint8 transpose) :
+MidiToolsDialog::MidiToolsDialog(const QString &lowerNote, const QString &higherNote, qint8 transpose, bool routingMidiInput) :
     QDialog(nullptr),
     ui(new Ui::MidiToolsDialog)
 {
@@ -30,6 +30,9 @@ MidiToolsDialog::MidiToolsDialog(const QString &lowerNote, const QString &higher
     ui->spinBoxTranspose->setMaximum(24);
     ui->spinBoxTranspose->setMinimum(-24);
     connect(ui->spinBoxTranspose, SIGNAL(valueChanged(int)), SLOT(transposeValueChanged(int)));
+
+    ui->checkBoxMidiRouting->setChecked(routingMidiInput);
+    connect(ui->checkBoxMidiRouting, &QCheckBox::toggled, this, &MidiToolsDialog::midiRoutingCheckBoxClicked);
 }
 
 MidiToolsDialog::~MidiToolsDialog()

--- a/src/Standalone/gui/MidiToolsDialog.h
+++ b/src/Standalone/gui/MidiToolsDialog.h
@@ -16,6 +16,8 @@ public:
     explicit MidiToolsDialog(const QString &lowerNote, const QString &higherNote, qint8 transpose, bool routingMidiInput);
     ~MidiToolsDialog();
     void setLearnedMidiNote(const QString &learnedNote);
+    void hideMidiRoutingControls();
+
 signals:
     void dialogClosed();
     void lowerNoteChanged(const QString &newLowerNote);

--- a/src/Standalone/gui/MidiToolsDialog.h
+++ b/src/Standalone/gui/MidiToolsDialog.h
@@ -13,7 +13,7 @@ class MidiToolsDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit MidiToolsDialog(const QString &lowerNote, const QString &higherNote, qint8 transpose);
+    explicit MidiToolsDialog(const QString &lowerNote, const QString &higherNote, qint8 transpose, bool routingMidiInput);
     ~MidiToolsDialog();
     void setLearnedMidiNote(const QString &learnedNote);
 signals:
@@ -23,6 +23,9 @@ signals:
 
     void transposeChanged(qint8 newTranspose);
     void learnMidiNoteClicked(bool); //this signal is fired when the 2 learn buttons are clicked
+
+    void midiRoutingCheckBoxClicked(bool checkBoxIsChecked);
+
 protected:
     void closeEvent(QCloseEvent *event);
 

--- a/src/Standalone/gui/MidiToolsDialog.ui
+++ b/src/Standalone/gui/MidiToolsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>237</width>
-    <height>208</height>
+    <height>257</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -200,6 +200,13 @@
        </layout>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="checkBoxMidiRouting">
+     <property name="text">
+      <string>Route MIDI input to first subchannel</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/resources/css/common/BaseTrack.css
+++ b/src/resources/css/common/BaseTrack.css
@@ -22,6 +22,13 @@
     color: rgb(50,50,50);
 }
 
+#soloButton:disabled,
+#muteButton:disabled
+{
+    color: rgba(0, 0, 0, 30);
+    border-color: rgba(0, 0, 0, 40);
+}
+
 /* button stereo inversion */
 QPushButton#buttonStereoInversion
 {

--- a/src/resources/css/common/General.css
+++ b/src/resources/css/common/General.css
@@ -31,7 +31,7 @@ QPushButton:checked
     color: rgb(0,0,0);
 }
 
-QPushButton[enabled="false"]        /* disabled buttons */
+QPushButton:disabled
 {
     background: none;
     color: rgba(0, 0, 0, 30);

--- a/src/resources/css/common/LocalTrack.css
+++ b/src/resources/css/common/LocalTrack.css
@@ -148,3 +148,9 @@ LocalTrackGroupView #groupNameField             /* The channel name for local tr
     padding-right: 0px;
     margin: 0px;
 }
+
+
+LocalTrackViewStandalone
+{
+    qproperty-midiRoutingArrowColor: rgba(255, 0, 0, 120);
+}

--- a/src/resources/css/common/LocalTrack.css
+++ b/src/resources/css/common/LocalTrack.css
@@ -8,6 +8,22 @@ FxPanelItem[containPlugin="false"]
     min-height: 14px; /* fixing #442 */
 }
 
+FxPanelItem:disabled
+{
+    background-color: none;
+    border: 1px solid rgba(0, 0, 0 , 10);
+}
+
+FxPanelItem QLabel:disabled
+{
+    color: rgba(0, 0, 0, 140);
+}
+
+FxPanelItem:disabled QPushButton:disabled
+{
+    background-color: rgba(255, 255, 255, 20);
+    border: 1px solid rgba(0, 0, 0, 50);
+}
 
 /* LocalTrackView is widget used to show the user tracks/subchannels.
 ----------------------------------------------------------------------*/

--- a/src/resources/css/themes/Black_nm/BaseTrack.css
+++ b/src/resources/css/themes/Black_nm/BaseTrack.css
@@ -34,6 +34,13 @@
    border-radius: 1px;
 }
 
+#buttonBoostMinus12:disabled,
+#buttonBoostPlus12:disabled,
+#buttonBoostZero:disabled
+{
+    color: rgba(0, 0, 0, 100);
+}
+
 #buttonBoostMinus12:checked,
 #buttonBoostPlus12:checked,
 #buttonBoostZero:checked

--- a/src/resources/css/themes/Black_nm/BaseTrack.css
+++ b/src/resources/css/themes/Black_nm/BaseTrack.css
@@ -187,7 +187,9 @@ BaseTrackView
 /* Setting colors when the track is 'not transmiting'
 -----------------------------------------------------*/
 BaseTrackView[unlighted="true"] #panSlider::handle,         /* pan slider handle */
-BaseTrackView[unlighted="true"] QSlider::handle:vertical    /* track fader handle */
+BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader handle */
+#panSlider::handle:disabled,
+QSlider::handle:vertical:disabled
 {
     border: rgb(140, 140, 140);
     background: rgb(80, 80, 80);

--- a/src/resources/css/themes/Black_nm/General.css
+++ b/src/resources/css/themes/Black_nm/General.css
@@ -248,13 +248,6 @@ QTabBar::tab:selected
     background-color: rgb(20, 20, 20);
 }
 
-QTabBar::tab:hover,
-QTabBar::tab:hover:checked
-{
-    color: rgb(140, 140,140);
-    background-color: rgb(30, 30, 30);
-}
-
 QTabBar::tab:!selected
 {
     margin-top: 3px; /* make non-selected tabs look smaller */
@@ -264,7 +257,7 @@ QTabBar::tab:!selected
 
 QTabBar::tab:!selected:hover
 {
-    background-color: rgb(20, 20, 20);
+    background-color: rgb(30, 30, 30);
 }
 
 QMenuBar::item
@@ -314,4 +307,13 @@ QMenu::item::enabled:selected
 QTabWidget::pane
 {
     background-color: transparent;
+}
+
+
+
+AudioMeter
+{
+    /* changing Audio Peak meter custom CSS properties */
+    qproperty-rmsColor: rgb(110, 110, 110);
+    qproperty-maxPeakColor: rgb(110, 110, 110);
 }

--- a/src/resources/css/themes/Black_nm/General.css
+++ b/src/resources/css/themes/Black_nm/General.css
@@ -31,7 +31,7 @@ QPushButton:hover:checked
     border: 1px outset rgb(10, 10, 10);
 }
 
-QPushButton[enabled="false"]
+QPushButton:disabled
 {
     background-color: rgba(0, 0, 0, 40);
     color: rgba(0, 0, 0, 100);
@@ -248,6 +248,13 @@ QTabBar::tab:selected
     background-color: rgb(20, 20, 20);
 }
 
+QTabBar::tab:hover,
+QTabBar::tab:hover:checked
+{
+    color: rgb(140, 140,140);
+    background-color: rgb(30, 30, 30);
+}
+
 QTabBar::tab:!selected
 {
     margin-top: 3px; /* make non-selected tabs look smaller */
@@ -257,7 +264,7 @@ QTabBar::tab:!selected
 
 QTabBar::tab:!selected:hover
 {
-    background-color: rgb(30, 30, 30);
+    background-color: rgb(20, 20, 20);
 }
 
 QMenuBar::item
@@ -307,13 +314,4 @@ QMenu::item::enabled:selected
 QTabWidget::pane
 {
     background-color: transparent;
-}
-
-
-
-AudioMeter
-{
-    /* changing Audio Peak meter custom CSS properties */
-    qproperty-rmsColor: rgb(110, 110, 110);
-    qproperty-maxPeakColor: rgb(110, 110, 110);
 }

--- a/src/resources/css/themes/Black_nm/LocalTrack.css
+++ b/src/resources/css/themes/Black_nm/LocalTrack.css
@@ -181,3 +181,10 @@ LocalTrackGroupView #groupNameField
             stop:1 rgba(25, 25, 25));
     border: 1px solid rgb(55, 55, 55);
 }
+
+
+
+LocalTrackViewStandalone
+{
+    qproperty-midiRoutingArrowColor: rgba(255, 255, 255, 80);
+}

--- a/src/resources/css/themes/Flat/BaseTrack.css
+++ b/src/resources/css/themes/Flat/BaseTrack.css
@@ -144,7 +144,9 @@ BaseTrackView
 /* Setting colors when the track is 'not transmiting'
 -----------------------------------------------------*/
 BaseTrackView[unlighted="true"] #panSlider::handle,         /* pan slider handle */
-BaseTrackView[unlighted="true"] QSlider::handle:vertical    /* track fader handle */
+BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader handle */
+#panSlider::handle:disabled,
+QSlider::handle:vertical:disabled
 {
     background: rgb(180, 180, 180);
 }

--- a/src/resources/css/themes/Ice/BaseTrack.css
+++ b/src/resources/css/themes/Ice/BaseTrack.css
@@ -187,7 +187,9 @@ BaseTrackView
 /* Setting colors when the track is 'not transmiting'
 -----------------------------------------------------*/
 BaseTrackView[unlighted="true"] #panSlider::handle,         /* pan slider handle */
-BaseTrackView[unlighted="true"] QSlider::handle:vertical    /* track fader handle */
+BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader handle */
+#panSlider::handle:disabled,
+QSlider::handle:vertical:disabled
 {
     background: rgba(0, 107, 206);
     Border: indent;

--- a/src/resources/css/themes/Rounded/BaseTrack.css
+++ b/src/resources/css/themes/Rounded/BaseTrack.css
@@ -151,7 +151,9 @@ PeakMeter
 
 }
 
-BaseTrackView[unlighted="true"] QSlider#panSlider::groove   /* pan slider 'track' when not xmiting */
+BaseTrackView[unlighted="true"] QSlider#panSlider::groove,   /* pan slider 'track' when not xmiting */
+#panSlider::handle:disabled,
+QSlider::handle:vertical:disabled
 {
     border: 1px solid rgba(0, 0, 0, 30);
 }

--- a/src/resources/css/themes/Volcano_nm/BaseTrack.css
+++ b/src/resources/css/themes/Volcano_nm/BaseTrack.css
@@ -172,10 +172,12 @@ stop: 1.0 #EF820D);
 /* Setting colors when the track is 'not transmiting'
 -----------------------------------------------------*/
 BaseTrackView[unlighted="true"] #panSlider::handle,         /* pan slider handle */
-BaseTrackView[unlighted="true"] QSlider::handle:vertical    /* track fader handle */
+BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader handle */
+#panSlider::handle:disabled,
+QSlider::handle:vertical:disabled
 {
-background: rgb(179, 89, 37);
-Border: none;
+    background: rgb(179, 89, 37);
+    Border: none;
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */


### PR DESCRIPTION
- [x] Add a checkbox in midi tools dialog to de/activate midi input routing.
- [x] Implementing midi routing in LocalInputNode
- [x] Implementing visual feedback in local tracks to show when midi routing is activated.
- [x] Disable buttons in second track when midi routing is enabled
- [x] Midi route checkbox will be available only in second subchannel.
- [x] Remember/save midi route status
- [x] Save/load midi route flag in presets
- [x] Disable midi input in second track when midi routing is enabled
- [x] Fix midi route drawing when local tracks are collapsed
- [x] disable all audio related controls (pan, fader, plugins etc) when routing midi.
- [x] If the user changes his mind and decides to use a normal subchannel (selecting audio input) the midi routing should be disabled
- [x] Fix midi activity meter when routing midi
- [x] Fix not intentional changes in Black theme
- [x] Reset track do not enable previously disabled buttons.