### PR TITLE
ALL THEMES fix for disabled Stereo inverse button

### DIFF
--- a/src/resources/css/common/BaseTrack.css
+++ b/src/resources/css/common/BaseTrack.css
@@ -39,8 +39,7 @@ QPushButton#buttonStereoInversion
     background-color: rgb(235, 235, 235);
 }
 
-LocalTrackView[unlighted="true"] #buttonStereoInversion,
-QPushButton#buttonStereoInversion[enabled="false"]
+LocalTrackView[unlighted="true"] #buttonStereoInversion
 {
     background-color: rgba(0, 0, 0, 30);
 }


### PR DESCRIPTION
Volcano theme is the one that shows the "wrong effect" most notably, but this happens to the other themes as well. When restarting Jamtaba if there was any stereo inverse button **disabled** previously (because of a mono track or midi routing) the color of the button appears _grayish_:

![image](https://cloud.githubusercontent.com/assets/15310433/22445932/c262bf28-e728-11e6-8480-932de5367ca1.png)

Can you check if this happens in your system too @elieserdejesus , please?

The issue is solved deleting this line in the code, but I don't know if it being there has another purpose that I'm unaware of.

This is the result:

![image](https://cloud.githubusercontent.com/assets/15310433/22446017/35f92ac6-e729-11e6-8ad7-8b6cc8c0bdb5.png)
