### PR TITLE
Ice theme combobox fix

### DIFF
--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -200,6 +200,7 @@ PluginScanDialog QGroupBox
 PrivateServerDialog #comboBoxServers
 {
     border: 1px solid rgba(0, 0, 0, 30);
+    padding: 1px 3px 1px 3px;
     background-color: rgb(180, 207, 250);
     color: rgba(0, 0, 0, 220);
     selection-background-color: rgb(51, 153, 255);

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -200,7 +200,7 @@ PluginScanDialog QGroupBox
 PrivateServerDialog #comboBoxServers
 {
     border: 1px solid rgba(0, 0, 0, 30);
-    padding: 1px 3px 1px 3px;
+    padding: 1px 2px 1px 2px;
     background-color: rgb(180, 207, 250);
     color: rgba(0, 0, 0, 220);
     selection-background-color: rgb(51, 153, 255);

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -46,11 +46,20 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
         stop:1 rgb(110, 165, 245));
 }
 
-PreferencesDialog QComboBox                         /* the colors inside the combo box*/
+#tabAudio QComboBox,                         /* the colors inside the combo box*/
+#tabLooper QComboBox,
+#tabMetronome QComboBox
 {
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 90);
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;
+}
+
+PreferencesDialog QPushButton
+{
+    border: 1px outset rgba(0, 0, 0, 90);
 }
 
 PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -52,6 +52,7 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
 {
     border-radius: 6px;
     border: 1px solid rgba(0, 0, 0, 90);
+    padding: 0px 0px 0px 0px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -66,6 +66,20 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
     color: white;
 }
 
+#tabAudio QComboBox:hover,
+#tabLooper QComboBox:hover,
+#tabMetronome QComboBox:hover
+{
+    background-color: rgb(207, 224, 252);
+}
+
+#tabAudio QComboBox:focus:hover,
+#tabLooper QComboBox:focus:hover,
+#tabMetronome QComboBox:focus:hover
+{
+    background-color: rgb(143, 188, 250);
+}
+
 #tabAudio QComboBox::drop-down,
 #tabLooper QComboBox::drop-down,
 #tabMetronome QComboBox::drop-down
@@ -80,9 +94,6 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
     image:url(:/images/arrow-down.png);
 }
 
-#tabAudio QComboBox::down-arrow:hover,
-#tabLooper QComboBox::down-arrow:hover,
-#tabMetronome QComboBox::down-arrown:hover,
 #tabAudio QComboBox::down-arrow:disabled,
 #tabLooper QComboBox::down-arrow:disabled,
 #tabMetronome QComboBox::down-arrow:disabled

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -52,7 +52,7 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
 {
     border-radius: 6px;
     border: 1px solid rgba(0, 0, 0, 90);
-    padding: 0px 0px 0px 0px;
+    padding: 1px 3px 1px 3px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;
@@ -64,6 +64,30 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
 {
     background-color: rgb(51, 153, 255);
     color: white;
+}
+
+#tabAudio QComboBox::drop-down,
+#tabLooper QComboBox::drop-down,
+#tabMetronome QComboBox::drop-down
+{
+    border: 0px;
+}
+
+#tabAudio QComboBox::down-arrow,
+#tabLooper QComboBox::down-arrow,
+#tabMetronome QComboBox::down-arrow
+{
+    image:url(:/images/arrow-down.png);
+}
+
+#tabAudio QComboBox::down-arrow:hover,
+#tabLooper QComboBox::down-arrow:hover,
+#tabMetronome QComboBox::down-arrown:hover,
+#tabAudio QComboBox::down-arrow:disabled,
+#tabLooper QComboBox::down-arrow:disabled,
+#tabMetronome QComboBox::down-arrow:disabled
+{
+    image:url(:/images/arrow-down-lighter.png);
 }
 
 PreferencesDialog QPushButton

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -12,7 +12,6 @@ QMessageBox,
 QInputDialog,
 MidiToolsDialog,
 UserNameDialog,
-PrivateServerDialog,
 LooperWindow
 {
     border-color: rgb(20, 20, 20);
@@ -197,10 +196,18 @@ PluginScanDialog QGroupBox
     selection-color: rgb(140, 140, 140);
 }
 
+PrivateServerDialog
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+        stop: 0.0 rgb(128, 180, 255),
+        stop: 1.0 rgb(126, 178, 255));
+}
+
 PrivateServerDialog #comboBoxServers
 {
-    border: 1px solid rgba(0, 0, 0, 30);
+    border: 1px solid rgba(0, 0, 0, 60);
     padding: 1px 2px 1px 2px;
+    border-radius: 6px;
     background-color: rgb(180, 207, 250);
     color: rgba(0, 0, 0, 220);
     selection-background-color: rgb(51, 153, 255);
@@ -209,7 +216,7 @@ PrivateServerDialog #comboBoxServers
 
 PrivateServerDialog #comboBoxServers:focus
 {
-    border-color: rgba(0, 0, 0, 100);
+    border-color: rgba(0, 0, 0, 90);
     color: black;
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;;

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -58,6 +58,14 @@ PreferencesDialog #tabAudio, #tabMidi, #tabVST, #tabRecording, #tabMetronome, #t
     selection-color: white;
 }
 
+#tabAudio QComboBox:focus,
+#tabLooper QComboBox:focus,
+#tabMetronome QComboBox:focus
+{
+    background-color: rgb(51, 153, 255);
+    color: white;
+}
+
 PreferencesDialog QPushButton
 {
     border: 1px outset rgba(0, 0, 0, 90);

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -214,6 +214,22 @@ PrivateServerDialog #comboBoxServers:focus
     selection-color: white;;
 }
 
+PrivateServerDialog #comboBoxServers::drop-down
+{
+    border: 0px;
+}
+
+PrivateServerDialog #comboBoxServers::down-arrow
+{
+    image:url(:/images/arrow-down.png);
+}
+
+PrivateServerDialog #comboBoxServers::down-arrow:disabled,
+PrivateServerDialog #comboBoxServers::down-arrow:hover
+{
+    image:url(:/images/arrow-down-lighter.png);
+}
+
 PrivateServerDialog QComboBox QAbstractItemView
 {
     border: none;

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -313,7 +313,7 @@ LooperWindow #buttonRec[blinking="true"]:checked
 {
     border-radius: 6px;
     border: 1px solid rgba(0, 0, 0, 90);
-    padding: 1px 2px 1px 2px;
+    padding: 1px 3px 1px 3px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;
@@ -323,6 +323,22 @@ LooperWindow #buttonRec[blinking="true"]:checked
 {
     background-color: rgb(51, 153, 255);
     color: white;
+}
+
+#widgetBottom QComboBox::drop-down
+{
+    border: 0px;
+}
+
+#widgetBottom QComboBox::down-arrow
+{
+    image:url(:/images/arrow-down.png);
+}
+
+#widgetBottom QComboBox::down-arrow:hover,
+#widgetBottom QComboBox::down-arrow:disabled
+{
+    image:url(:/images/arrow-down-lighter.png);
 }
 
 LooperWindow #maxLayersComboBox
@@ -349,11 +365,6 @@ LooperWindow QLabel:disabled,
 LooperWindow QComboBox:disabled
 {
     color: rgba(0, 0, 0, 90);
-}
-
-LooperWindow QComboBox::down-arrow:disabled
-{
-    image:url(:/images/arrow-down-lighter.png);
 }
 
 LooperWindow QLabel,

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -325,6 +325,16 @@ LooperWindow #buttonRec[blinking="true"]:checked
     color: white;
 }
 
+#widgetBottom QComboBox:hover
+{
+    background-color: rgb(207, 224, 252);
+}
+
+#widgetBottom QComboBox:focus:hover
+{
+    background-color: rgb(143, 188, 250);
+}
+
 #widgetBottom QComboBox::drop-down
 {
     border: 0px;
@@ -335,7 +345,6 @@ LooperWindow #buttonRec[blinking="true"]:checked
     image:url(:/images/arrow-down.png);
 }
 
-#widgetBottom QComboBox::down-arrow:hover,
 #widgetBottom QComboBox::down-arrow:disabled
 {
     image:url(:/images/arrow-down-lighter.png);

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -312,6 +312,7 @@ LooperWindow #buttonRec[blinking="true"]:checked
 #widgetBottom QComboBox                         /* the colors inside the combo box*/
 {
     border-radius: 6px;
+    min-width: 1em;
     border: 1px solid rgba(0, 0, 0, 90);
     padding: 0px 0px 0px 0px;
     background-color: rgb(180, 207, 250);

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -312,9 +312,8 @@ LooperWindow #buttonRec[blinking="true"]:checked
 #widgetBottom QComboBox                         /* the colors inside the combo box*/
 {
     border-radius: 6px;
-    min-width: 1em;
     border: 1px solid rgba(0, 0, 0, 90);
-    padding: 0px 0px 0px 0px;
+    padding: 2px 5px 2px 5px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;
@@ -324,6 +323,16 @@ LooperWindow #buttonRec[blinking="true"]:checked
 {
     background-color: rgb(51, 153, 255);
     color: white;
+}
+
+LooperWindow #maxLayersComboBox
+{
+    min-width: 1em;
+}
+
+LooperWindow #comboBoxPlayMode
+{
+    min-width: 7em;
 }
 
 LooperWindow QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -319,6 +319,12 @@ LooperWindow #buttonRec[blinking="true"]:checked
     selection-color: white;
 }
 
+#widgetBottom QComboBox:focus
+{
+    background-color: rgb(51, 153, 255);
+    color: white;
+}
+
 LooperWindow QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/
 {
     border: none;

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -309,8 +309,11 @@ LooperWindow #buttonRec[blinking="true"]:checked
     background-color: rgb(180, 207, 250);
 }
 
-LooperWindow QComboBox                         /* the colors inside the combo box*/
+#widgetBottom QComboBox                         /* the colors inside the combo box*/
 {
+    border-radius: 6px;
+    border: 1px solid rgba(0, 0, 0, 90);
+    padding: 0px 0px 0px 0px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -313,7 +313,7 @@ LooperWindow #buttonRec[blinking="true"]:checked
 {
     border-radius: 6px;
     border: 1px solid rgba(0, 0, 0, 90);
-    padding: 2px 5px 2px 5px;
+    padding: 1px 2px 1px 2px;
     background-color: rgb(180, 207, 250);
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;


### PR DESCRIPTION
This PR rounds the comboboxes borders for the ice theme to match the overall theme concept where there were still squared (in **preferences** and **looper window**). Pending is the squared private server combobox which I still can't find a way to round the borders.

EDIT: I found the problem with the private server combobox. It's solved now.