### PR TITLE
Some minor volcano, black and ice style fixes

### DIFF
--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -374,10 +374,14 @@ LooperWindow QComboBox QAbstractItemView      /* the colors inside drop down men
 }
 
 LooperWindow QCheckBox:disabled,
-LooperWindow QLabel:disabled,
-LooperWindow QComboBox:disabled
+LooperWindow QLabel:disabled
 {
     color: rgba(0, 0, 0, 90);
+}
+
+#widgetBottom QComboBox:disabled
+{
+    border: none;
 }
 
 LooperWindow QLabel,

--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -205,7 +205,7 @@ PrivateServerDialog
 
 PrivateServerDialog #comboBoxServers
 {
-    border: 1px solid rgba(0, 0, 0, 60);
+    border: 1px solid rgba(0, 0, 0, 90);
     padding: 1px 2px 1px 2px;
     border-radius: 6px;
     background-color: rgb(180, 207, 250);
@@ -216,7 +216,7 @@ PrivateServerDialog #comboBoxServers
 
 PrivateServerDialog #comboBoxServers:focus
 {
-    border-color: rgba(0, 0, 0, 90);
+    border-color: rgba(0, 0, 0, 120);
     color: black;
     selection-background-color: rgb(51, 153, 255);
     selection-color: white;;

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -322,6 +322,7 @@ LooperWindow #buttonRec[blinking="true"]:checked
 #widgetBottom QComboBox:focus
 {
     background-color: rgb(51, 153, 255);
+    border-color: rgba(0, 0, 0, 160);
     color: white;
 }
 

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -371,10 +371,14 @@ LooperWindow QComboBox QAbstractItemView      /* the colors inside drop down men
 }
 
 LooperWindow QCheckBox:disabled,
-LooperWindow QLabel:disabled,
-LooperWindow QComboBox:disabled
+LooperWindow QLabel:disabled
 {
     color: rgba(0, 0, 0, 90);
+}
+
+#widgetBottom QComboBox:disabled
+{
+    border: none;
 }
 
 LooperWindow QLabel,

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -385,6 +385,7 @@ LooperWindow QGroupBox
 LooperWindow QGroupBox
 {
     border: 1px solid rgba(0, 0, 0, 30);
+    border-radius: 6px;
 }
 
 LooperWindow QCheckBox

--- a/src/resources/css/themes/Volcano_nm/BaseTrack.css
+++ b/src/resources/css/themes/Volcano_nm/BaseTrack.css
@@ -96,6 +96,7 @@ BaseTrackView[unlighted="true"] #buttonBoost:checked
     border-top: none;
     border-style: solid;
     border-color: rgba(0, 0, 0, 60);
+    color: rgb(254, 181, 102);
 }
 
 #soloButton, #muteButton

--- a/src/resources/css/themes/Volcano_nm/Dialogs.css
+++ b/src/resources/css/themes/Volcano_nm/Dialogs.css
@@ -144,7 +144,7 @@ PluginScanDialog QGroupBox
 
 PrivateServerDialog #comboBoxServers
 {
-    border: 1px solid rgba(0, 0, 0, 30);
+    border: 1px solid rgba(0, 0, 0, 100);
     padding: 1px 2px 1px 2px;
     background-color: rgb(254, 181, 102);
     color: rgba(0, 0, 0, 220);
@@ -154,7 +154,7 @@ PrivateServerDialog #comboBoxServers
 
 PrivateServerDialog #comboBoxServers:focus
 {
-    border-color: rgba(0, 0, 0, 100);
+    border-color: rgba(0, 0, 0, 160);
     color: black;
     selection-background-color: rgb(179, 89, 37);
     selection-color: rgba(254, 181, 102, 150);

--- a/src/resources/css/themes/Volcano_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano_nm/NinjamWindow.css
@@ -313,10 +313,14 @@ LooperWindow QComboBox QAbstractItemView      /* the colors inside drop down men
 }
 
 LooperWindow QCheckBox:disabled,
-LooperWindow QLabel:disabled,
-LooperWindow QComboBox:disabled
+LooperWindow QLabel:disabled
 {
     color: rgba(0, 0, 0, 90);
+}
+
+#widgetBottom QComboBox:disabled
+{
+    border: none;
 }
 
 LooperWindow QComboBox:disabled

--- a/src/resources/css/themes/Volcano_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano_nm/NinjamWindow.css
@@ -247,6 +247,7 @@ LooperWindow #buttonRec[blinking="true"]:checked
 #widgetBottom QComboBox                         /* the colors inside the combo box*/
 {
     border: 1px solid rgba(0, 0, 0, 180);
+    border-radius: 2px;
     padding: 1px 3px 1px 3px;
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
         stop: 0.0 #FDE5A9,
@@ -332,6 +333,7 @@ LooperWindow QGroupBox
 LooperWindow QGroupBox
 {
     border: 1px solid rgba(0, 0, 0, 30);
+    border-radius: 2px;
 }
 
 LooperWindow QCheckBox


### PR DESCRIPTION
1.- matching some rounded borders missing for Ice and volcano theme.
2.- volcano theme boost font color match to palette when checked.
3.- volcano, ice themes border fix
4.- looper comboboxes disabled border fix for ice, volcano and black themes