### PR TITLE
Volcano/Flat themes improving RMS/max peak color

### DIFF
--- a/src/resources/css/themes/Flat/General.css
+++ b/src/resources/css/themes/Flat/General.css
@@ -257,8 +257,14 @@ QMenu
 AudioMeter
 {
     /* changing Audio Peak meter custom CSS properties */
-    qproperty-rmsColor: rgb(120, 120, 120);
+    qproperty-rmsColor: rgb(150, 150, 150);
     qproperty-peakStartColor: rgb(0, 180, 0);
     qproperty-peakEndColor: rgb(255, 50, 50);
+    qproperty-maxPeakColor: rgb(150, 150, 150);
+}
+
+AudioMeter#masterMeter
+{
     qproperty-maxPeakColor: rgb(120, 120, 120);
+    qproperty-rmsColor: rgb(120, 120, 120);
 }

--- a/src/resources/css/themes/Volcano_nm/General.css
+++ b/src/resources/css/themes/Volcano_nm/General.css
@@ -336,7 +336,13 @@ AudioMeter
     qproperty-rmsColor: rgb(181, 37, 3);
     qproperty-peakStartColor: orange;
     qproperty-peakEndColor: red;
-    qproperty-maxPeakColor: rgb(190, 90, 20);
+    qproperty-maxPeakColor: rgb(181, 37, 3);
+}
+
+AudioMeter#masterMeter
+{
+    qproperty-maxPeakColor: rgb(190, 90, 29);
+    qproperty-rmsColor: rgb(190, 90, 29);
 }
 
 AudioMeter#masterMeter


### PR DESCRIPTION
Max peak meter in volcano theme when track is not xmitting was invisible, so I used the same color of the RMS meter.

I kept the original color used for the master RMS meter in volcano as it's matching better the overall palette for theme.

Max peak meter in flat theme when track is not xmitting was invisible too, so I changed the color to average the grays