### PR TITLE
fixing looper width to fit polish translation

### DIFF
--- a/src/Common/gui/LooperWindow.ui
+++ b/src/Common/gui/LooperWindow.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>782</width>
+    <width>801</width>
     <height>500</height>
    </rect>
   </property>
@@ -457,7 +457,6 @@
   </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../resources/jamtaba.qrc"/>
   <include location="../../resources/jamtaba.qrc"/>
  </resources>
  <connections/>


### PR DESCRIPTION
Polish translation needed a little more space. The max layer combobox was shrunk and did not appear of correct size in some cases:

![image](https://cloud.githubusercontent.com/assets/15310433/25588492/e33016cc-2e7e-11e7-821f-8a91f43f9b39.png)


