### PR TITLE
Fix appdmg invocation in mac installer.sh would assume eli user folde…

### DIFF
--- a/installers/mac/installer.sh
+++ b/installers/mac/installer.sh
@@ -32,7 +32,7 @@ echo “Compiling …”
 cp -R ~/Desktop/Release/Standalone/Jamtaba2.app ~/Desktop/JamTaba/installers/mac/
 cp -R /Library/Audio/Plug-Ins/Components/JamTaba.component ~/Desktop/JamTaba/installers/mac
 
-appdmg /Users/elieser/Desktop/JamTaba/installers/mac/node-appdmg.json ~/Desktop/Jamtaba_2_Installer.dmg
+appdmg ~/Desktop/JamTaba/installers/mac/node-appdmg.json ~/Desktop/Jamtaba_2_Installer.dmg
 
 
 #removing the .app and AU files


### PR DESCRIPTION
…r hardcoded path.