### PR TITLE
pref dialog font color fix for ice theme

### DIFF
--- a/src/resources/css/themes/Ice/Dialogs.css
+++ b/src/resources/css/themes/Ice/Dialogs.css
@@ -105,6 +105,11 @@ PreferencesDialog QPushButton
     border: 1px outset rgba(0, 0, 0, 90);
 }
 
+PreferencesDialog QComboBox
+{
+    color: black;
+}
+
 PreferencesDialog QComboBox QAbstractItemView      /* the colors inside drop down menu of the combo box*/
 {
     border: none;


### PR DESCRIPTION
The camera combo box font color overrides the preferences combobox font color in ice theme (standalone)