### PR TITLE
All themes color fixes

### DIFF
--- a/src/resources/css/themes/Black_nm/LocalTrack.css
+++ b/src/resources/css/themes/Black_nm/LocalTrack.css
@@ -90,6 +90,12 @@ LocalTrackGroupView[unlighted="true"] #topPanel
     background: rgb(40, 40, 40);
 }
 
+LocalTrackView[unlighted="true"] #panSlider::handle:hover,
+LocalTrackView[unlighted="true"] #levelSlider::handle:hover
+{
+    background-color: rgb(120, 120, 120);
+}
+
 LocalTrackView #inputSelectionButton            /* Button used to open the input selection menu */
 {
     background-color: none;

--- a/src/resources/css/themes/Black_nm/LocalTrack.css
+++ b/src/resources/css/themes/Black_nm/LocalTrack.css
@@ -84,6 +84,12 @@ LocalTrackView[highlighted="true"]
     stop:1 rgb(40, 40, 40));
 }
 
+LocalTrackView[unlighted="true"],
+LocalTrackGroupView[unlighted="true"] #topPanel
+{
+    background: rgb(40, 40, 40);
+}
+
 LocalTrackView #inputSelectionButton            /* Button used to open the input selection menu */
 {
     background-color: none;

--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -246,12 +246,7 @@ IntervalProgressWindow
 
 #panelCombos QComboBox:hover
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-        stop: 0.0 rgb(31, 31, 31),
-        stop: 0.1 rgb(63, 63, 63),
-        stop: 0.45 rgb(63, 63, 63),
-        stop: 0.6 rgb(31, 31, 31),
-        stop: 1.0 rgb(31, 31, 31))
+    background-color: rgb(31, 31, 31);
 }
 
 #comboBpi-topLevel

--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -244,6 +244,16 @@ IntervalProgressWindow
     selection-color: black;
 }
 
+#panelCombos QComboBox:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop: 0.0 rgb(31, 31, 31),
+        stop: 0.1 rgb(63, 63, 63),
+        stop: 0.45 rgb(63, 63, 63),
+        stop: 0.6 rgb(31, 31, 31),
+        stop: 1.0 rgb(31, 31, 31))
+}
+
 #comboBpi-topLevel
 {
     background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -230,6 +230,16 @@ NinjamPanel QComboBox QAbstractItemView
     selection-color: white;
 }
 
+#panelCombos QComboBox:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop: 0.0 rgb(112, 149, 174),
+        stop: 0.1 rgb(117, 171, 225),
+        stop: 0.45 rgb(117, 171, 225),
+        stop: 0.6 rgb(112, 149, 174),
+        stop: 1.0 rgb(112, 149, 174));
+}
+
 #comboBpi-topLevel
 {
     border: none;

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -232,12 +232,7 @@ NinjamPanel QComboBox QAbstractItemView
 
 #panelCombos QComboBox:hover
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-        stop: 0.0 rgb(112, 149, 174),
-        stop: 0.1 rgb(117, 171, 225),
-        stop: 0.45 rgb(117, 171, 225),
-        stop: 0.6 rgb(112, 149, 174),
-        stop: 1.0 rgb(112, 149, 174));
+    background-color: rgb(112, 149, 174);
 }
 
 #comboBpi-topLevel

--- a/src/resources/css/themes/Rounded/LocalTrack.css
+++ b/src/resources/css/themes/Rounded/LocalTrack.css
@@ -77,7 +77,7 @@ FxPanelItem QPushButton:checked
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.9, stop:0 rgba(255, 90, 62, 140), stop:1 rgba(175, 0, 0, 140));
     border-color: rgb(50,50,50);
-    color: rgb(140, 140, 140);
+    color: rgb(20, 20, 20);
 }
 
 #xmitButton:hover

--- a/src/resources/css/themes/Volcano_nm/LocalTrack.css
+++ b/src/resources/css/themes/Volcano_nm/LocalTrack.css
@@ -74,6 +74,12 @@ LocalTrackView[highlighted="true"]
     background: rgba(255, 255, 255, 40);
 }
 
+LocalTrackView[unlighted="true"],
+LocalTrackGroupView[unlighted="true"] #topPanel
+{
+    background: rgb(193, 106, 48);
+}
+
 LocalTrackView #inputPanel
 {
     background-color: rgba(255, 106, 0, 100);

--- a/src/resources/css/themes/Volcano_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano_nm/NinjamWindow.css
@@ -192,6 +192,16 @@ selection-background-color: rgba(0, 0, 0, 90);
 selection-color: rgb(254, 181, 102);
 }
 
+#panelCombos QComboBox:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
+        stop: 0.0 rgb(184, 149, 124),
+        stop: 0.1 rgb(227, 183, 153),
+        stop: 0.45 rgb(227, 183, 153),
+        stop: 0.6 rgb(184, 149, 124),
+        stop: 1.0 rgb(184, 149, 124));
+}
+
 #comboBpi-topLevel,
 #comboBpm-topLevel
 {

--- a/src/resources/css/themes/Volcano_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano_nm/NinjamWindow.css
@@ -194,12 +194,7 @@ selection-color: rgb(254, 181, 102);
 
 #panelCombos QComboBox:hover
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:1, y2:0,
-        stop: 0.0 rgb(184, 149, 124),
-        stop: 0.1 rgb(227, 183, 153),
-        stop: 0.45 rgb(227, 183, 153),
-        stop: 0.6 rgb(184, 149, 124),
-        stop: 1.0 rgb(184, 149, 124));
+    background-color: rgb(184, 149, 124);
 }
 
 #comboBpi-topLevel,


### PR DESCRIPTION
- [x] ninjampanel hover has wrong colors for black and volcano themes

![image](https://user-images.githubusercontent.com/15310433/31320376-05d893b8-ac4a-11e7-9d02-c32da86ad669.png)

- [x] wrong disabled local channel color for volcano and black theme

![image](https://user-images.githubusercontent.com/15310433/31320496-d160e9da-ac4b-11e7-8890-669219219be2.png)

- [x] Black theme disabled channel's fader hover not working (local and remote channels)

- [x] rounded theme's Xmit button when disabled using not the best contrasting color : 

![image](https://user-images.githubusercontent.com/15310433/31320537-8d1045fe-ac4c-11e7-8b0a-9cbb9fe8c701.png)

- [x] Black theme channel name placeholder when disabled looks a bit out of place

![image](https://user-images.githubusercontent.com/15310433/31322259-ceb3d1ce-ac6a-11e7-9a53-aa89544e07d4.png)



fixes posted in https://github.com/elieserdejesus/JamTaba/issues/911