### PR TITLE
black theme remote disabled channels hover fix

### DIFF
--- a/src/resources/css/themes/Black_nm/BaseTrack.css
+++ b/src/resources/css/themes/Black_nm/BaseTrack.css
@@ -172,6 +172,13 @@ BaseTrackView[unlighted="true"] #levelSlider::handle:vertical,    /* track fader
     background: rgb(80, 80, 80);
 }
 
+
+BaseTrackView[unlighted="true"] #panSlider::handle:hover,
+BaseTrackView[unlighted="true"] #levelSlider::handle:hover
+{
+    background-color: rgb(120, 120, 120);
+}
+
 BaseTrackView[unlighted="true"],                            /* the track */
 TrackGroupView[unlighted="true"] > #topPanel                /* the track group top panel: used to show user name */
 {

--- a/src/resources/css/themes/Black_nm/LocalTrack.css
+++ b/src/resources/css/themes/Black_nm/LocalTrack.css
@@ -90,12 +90,6 @@ LocalTrackGroupView[unlighted="true"] #topPanel
     background: rgb(40, 40, 40);
 }
 
-LocalTrackView[unlighted="true"] #panSlider::handle:hover,
-LocalTrackView[unlighted="true"] #levelSlider::handle:hover
-{
-    background-color: rgb(120, 120, 120);
-}
-
 LocalTrackView #inputSelectionButton            /* Button used to open the input selection menu */
 {
     background-color: none;


### PR DESCRIPTION
In Black theme, the hover for disabled channels only was applied to local channels, not remoteones. This PR fixxes the issue.