### PR TITLE
Showing camera icon/video when local channels are collapsed

### DIFF
--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -641,12 +641,13 @@ void MainWindow::showPeakMetersOnlyInLocalControls(bool showPeakMetersOnly)
 
     if (cameraView) {
         cameraCombo->setVisible(cameraView->isVisible() && cameraCombo->count() > 1);
-    }
-    if (!showPeakMetersOnly) {
+        
+        if (!showPeakMetersOnly) {
             cameraView->setMaximumHeight(90);
-    }
-    else {
+        }
+        else {
         cameraView->setMaximumHeight(32);
+        }
     }
     
     updateLocalInputChannelsGeometry();

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -640,10 +640,15 @@ void MainWindow::showPeakMetersOnlyInLocalControls(bool showPeakMetersOnly)
     ui.localControlsCollapseButton->setChecked(showPeakMetersOnly);
 
     if (cameraView) {
-        cameraView->setVisible(!showPeakMetersOnly);
         cameraCombo->setVisible(cameraView->isVisible() && cameraCombo->count() > 1);
     }
-
+    if (!showPeakMetersOnly) {
+            cameraView->setMaximumHeight(90);
+    }
+    else {
+        cameraView->setMaximumHeight(32);
+    }
+    
     updateLocalInputChannelsGeometry();
 
     ui.userNamePanel->setVisible(!showPeakMetersOnly);


### PR DESCRIPTION
Proposing this change because when you use the local channels collapsed, there's no way to turn the camera on/off (nor know if video is being transmitted) unless you expand them.

![image](https://user-images.githubusercontent.com/15310433/37295888-1f244a1a-25f8-11e8-8350-a7053bdca67f.png)
