### PR TITLE
Making fader/pan handles semi-transparent

### DIFF
--- a/src/resources/css/themes/Black_nm/BaseTrack.css
+++ b/src/resources/css/themes/Black_nm/BaseTrack.css
@@ -127,7 +127,7 @@ BaseTrackView[unlighted="true"] #levelSlider::handle:vertical,    /* track fader
 #levelSlider::handle:vertical:disabled
 {
     border: 1px outset rgba(60, 60, 60, 180);
-    background: rgb(80, 80, 80, 180);
+    background: rgb(80, 80, 80, 200);
 }
 
 

--- a/src/resources/css/themes/Black_nm/BaseTrack.css
+++ b/src/resources/css/themes/Black_nm/BaseTrack.css
@@ -126,8 +126,8 @@ BaseTrackView[unlighted="true"] #levelSlider::handle:vertical,    /* track fader
 #panSlider::handle:disabled,
 #levelSlider::handle:vertical:disabled
 {
-    border: 1px outset rgb(60, 60, 60);
-    background: rgb(80, 80, 80);
+    border: 1px outset rgba(60, 60, 60, 180);
+    background: rgb(80, 80, 80, 180);
 }
 
 
@@ -148,15 +148,22 @@ TrackGroupView[unlighted="true"] > #topPanel                /* the track group t
 #panSlider::handle,
 #levelSlider::handle
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
-    border: 1px outset rgb(30, 30, 30);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+        stop:0 rgba(180, 180, 180, 140),
+        stop:1 rgba(120, 120, 120, 140));
+
+    border: 1px outset rgba(30, 30, 30, 140);
 
 }
 
 #panSlider::handle:hover,
 #levelSlider::handle:hover
 {
-    background-color: rgb(180, 180, 180);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+        stop:0 rgba(180, 180, 180, 180),
+        stop:1 rgba(120, 120, 120, 180));
+
+    border: 1px outset rgb(30, 30, 30);
 }
 
 AudioMeter

--- a/src/resources/css/themes/Black_nm/General.css
+++ b/src/resources/css/themes/Black_nm/General.css
@@ -227,10 +227,10 @@ QSlider::groove
 QSlider::handle:horizontal
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
-        stop:0 rgba(120, 120, 120, 180),
-        stop:1 rgba(60, 60, 60, 180));
+        stop:0 rgba(120, 120, 120, 140),
+        stop:1 rgba(60, 60, 60, 140));
 
-    border: 1px outset rgb(10, 10, 10);
+    border: 1px outset rgba(10, 10, 10, 140);
     border-radius: 2px;
     padding: 0px;
     width: 8px;
@@ -239,10 +239,10 @@ QSlider::handle:horizontal
 QSlider::handle:vertical
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
-        stop:0 rgba(180, 180, 180, 180),
-        stop:1 rgba(120, 120, 120, 180));
+        stop:0 rgba(180, 180, 180, 140),
+        stop:1 rgba(120, 120, 120, 140));
 
-    border: 1px outset rgb(30, 30, 30);
+    border: 1px outset rgba(30, 30, 30, 140);
     border-radius: 2px;
     padding: 0px;
     height: 9px;
@@ -250,12 +250,20 @@ QSlider::handle:vertical
 
 QSlider::handle:horizontal:hover
 {
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+        stop:0 rgba(120, 120, 120, 180),
+        stop:1 rgba(60, 60, 60, 180));
+
+    border: 1px outset rgb(10, 10, 10);
 }
 
 QSlider::handle:vertical:hover
 {
-    background-color: rgb(140, 140, 140);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+    stop:0 rgba(180, 180, 180, 180),
+    stop:1 rgba(120, 120, 120, 180));
+
+    border: 1px outset rgb(30, 30, 30);
 }
 
 

--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -65,14 +65,17 @@ NinjamTrackView[horizontal="true"]
 
 NinjamTrackView[unlighted="true"][horizontal="true"] #levelSlider::handle:horizontal
 {
-    border: rgb(140, 140, 140);
-    background: rgb(80, 80, 80);
+    border: rgba(140, 140, 140, 180);
+    background: rgba(80, 80, 80, 180);
 }
 
 NinjamTrackView[horizontal="true"] #levelSlider::handle:horizontal
 {
-    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95, stop:0 rgb(180, 180, 180), stop:1 rgb(120, 120, 120));
-    border: 1px outset rgb(30, 30, 30);
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+        stop:0 rgba(180, 180, 180, 220),
+        stop:1 rgba(120, 120, 120, 220));
+
+    border: 1px outset rgba(30, 30, 30, 200);
 }
 
 /* Tool buttons: track vertical/horizontal/grid, wide/narrow and server licence buttons

--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -45,6 +45,20 @@ NinjamTrackView[horizontal="true"] #panSlider
     max-width: 50px;
 }
 
+NinjamTrackView[horizontal="true"] #levelSlider::handle:horizontal:hover
+{
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
+        stop:0 rgba(180, 180, 180, 180),
+        stop:1 rgba(120, 120, 120, 180));
+
+    border: 1px outset rgb(30, 30, 30);
+}
+
+NinjamTrackView[horizontal="true"][unlighted="true"] #levelSlider::handle:horizontal:hover
+{
+    background-color: rgb(120, 120, 120);
+}
+
 NinjamTrackView[horizontal="true"] QPushButton#lowCutButton:hover:checked,
 NinjamTrackView[horizontal="true"] QPushButton#receiveButton:checked,
 NinjamTrackView QPushButton#lowCutButton:hover:checked,
@@ -72,10 +86,10 @@ NinjamTrackView[unlighted="true"][horizontal="true"] #levelSlider::handle:horizo
 NinjamTrackView[horizontal="true"] #levelSlider::handle:horizontal
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
-        stop:0 rgba(180, 180, 180, 180),
-        stop:1 rgba(120, 120, 120, 180));
+        stop:0 rgba(180, 180, 180, 140),
+        stop:1 rgba(120, 120, 120, 140));
 
-    border: 1px outset rgba(30, 30, 30, 200);
+    border: 1px outset rgba(30, 30, 30, 140);
 }
 
 /* Tool buttons: track vertical/horizontal/grid, wide/narrow and server licence buttons

--- a/src/resources/css/themes/Black_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Black_nm/NinjamWindow.css
@@ -72,8 +72,8 @@ NinjamTrackView[unlighted="true"][horizontal="true"] #levelSlider::handle:horizo
 NinjamTrackView[horizontal="true"] #levelSlider::handle:horizontal
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:0.95,
-        stop:0 rgba(180, 180, 180, 220),
-        stop:1 rgba(120, 120, 120, 220));
+        stop:0 rgba(180, 180, 180, 180),
+        stop:1 rgba(120, 120, 120, 180));
 
     border: 1px outset rgba(30, 30, 30, 200);
 }

--- a/src/resources/css/themes/Flat/BaseTrack.css
+++ b/src/resources/css/themes/Flat/BaseTrack.css
@@ -111,7 +111,7 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgba(180, 180, 180, 150);
+    background: rgba(180, 180, 180, 200);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Flat/BaseTrack.css
+++ b/src/resources/css/themes/Flat/BaseTrack.css
@@ -111,7 +111,7 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgb(180, 180, 180);
+    background: rgba(180, 180, 180, 150);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Flat/General.css
+++ b/src/resources/css/themes/Flat/General.css
@@ -177,14 +177,14 @@ QSlider::groove:vertical
 
 QSlider::handle
 {
-    background: rgb(245, 245, 245);
+    background: rgba(245, 245, 245, 150);
     border: 1px outset rgb(120, 120, 120);
     border-radius: 2px;
 }
 
 QSlider::handle:hover
 {
-    background: rgb(250, 250, 250);
+    background: rgb(245, 245, 245);
     border: 1px outset rgb(90, 90, 90);
 }
 

--- a/src/resources/css/themes/Flat/NinjamWindow.css
+++ b/src/resources/css/themes/Flat/NinjamWindow.css
@@ -24,7 +24,7 @@ NinjamTrackView[horizontal="true"][unlighted="true"]
 
 NinjamTrackView[unlighted="true"][horizontal="true"] QSlider::handle:horizontal
  {
-     background: rgb(180, 180, 180);
+     background: rgba(180, 180, 180, 200);
  }
 
 /* Tool buttons: track vertical/horizontal/grid, wide/narrow and server licence buttons

--- a/src/resources/css/themes/Game_nm/General.css
+++ b/src/resources/css/themes/Game_nm/General.css
@@ -127,17 +127,17 @@ MetronomePanel QSlider::groove:horizontal
 QSlider::handle:vertical,
 QSlider::handle:horizontal
 {
-    background: #519987;
+    background: rgba(81,153,135,160);
 
     padding: 0px;
-    border: none;
+    border: #77E5E5;
 }
 
 QSlider::handle:vertical:hover,
 QSlider::handle:horizontal:hover
 {
-    background: #58A996;
-    border: 1px solid #77E5E5;
+    background: #519987;
+    border: none;
 }
 
 QSlider::handle:vertical

--- a/src/resources/css/themes/Game_nm/General.css
+++ b/src/resources/css/themes/Game_nm/General.css
@@ -137,7 +137,7 @@ QSlider::handle:vertical:hover,
 QSlider::handle:horizontal:hover
 {
     background: #519987;
-    border: none;
+    border: 1px solid #77E5E5;
 }
 
 QSlider::handle:vertical

--- a/src/resources/css/themes/Ice/BaseTrack.css
+++ b/src/resources/css/themes/Ice/BaseTrack.css
@@ -135,8 +135,8 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgba(0, 107, 206, 155);
-    border: 1px outset rgba(0, 80, 151, 180);
+    background: rgba(0, 107, 206, 180);
+    border: 1px outset rgba(0, 80, 151, 200);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Ice/BaseTrack.css
+++ b/src/resources/css/themes/Ice/BaseTrack.css
@@ -135,8 +135,8 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgba(0, 107, 206);
-    border: 1px outset rgb(0, 80, 151);
+    background: rgba(0, 107, 206, 155);
+    border: 1px outset rgba(0, 80, 151, 180);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Ice/General.css
+++ b/src/resources/css/themes/Ice/General.css
@@ -197,15 +197,16 @@ QSlider::groove:vertical
 QSlider::handle
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop: 0.0 rgb(190,217,255),
-        stop: 1.0 rgb(180,207,250));
+        stop: 0.0 rgba(190, 217, 255, 125),
+        stop: 1.0 rgba(180, 207, 250, 125));
 
-    border: 1px outset rgba(0, 0, 0, 180);
+    border: 1px outset rgba(0, 0, 0, 80);
 }
 
 QSlider::handle:hover
 {
-    background-color: rgb(221, 235, 255);
+    background-color: rgb(190, 217, 255);
+     border: 1px outset rgba(0, 0, 0, 180);
 }
 
 QSlider::handle:horizontal

--- a/src/resources/css/themes/Ice/NinjamWindow.css
+++ b/src/resources/css/themes/Ice/NinjamWindow.css
@@ -45,7 +45,7 @@ NinjamTrackView[horizontal="true"][unlighted="true"]
 
 NinjamTrackView[unlighted="true"][horizontal="true"] QSlider::handle:horizontal
 {
-    background: rgb(0,107,206);
+    background: rgba(0, 107, 206, 200);
     Border: none;
 }
 

--- a/src/resources/css/themes/Navy_nm/General.css
+++ b/src/resources/css/themes/Navy_nm/General.css
@@ -142,14 +142,14 @@ BoostSpinBox QToolButton:!enabled:!checked
 QSlider::handle
 {
     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                stop: 0.0 rgb(115, 115, 115),
-                stop: 1.0 rgb(89, 89, 89));
+                stop: 0.0 rgba(115, 115, 115, 150),
+                stop: 1.0 rgba(89, 89, 89, 150));
 }
 
 QSlider::handle:hover
 {
     background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1,
-                stop: 0.0 rgb(155, 155, 155), stop: 1.0 rgb(119, 119, 119));
+                stop: 0.0 rgb(115, 115, 115), stop: 1.0 rgb(89, 89, 89));
 }
 
 QSlider::groove,

--- a/src/resources/css/themes/Rounded/BaseTrack.css
+++ b/src/resources/css/themes/Rounded/BaseTrack.css
@@ -99,10 +99,10 @@ BaseTrackView[unlighted="true"]
 #panSlider::handle
 {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-        stop: 0      rgb(230, 230, 230),
-        stop: 0.8    rgb(180, 180, 180));
+        stop: 0      rgba(230, 230, 230, 140),
+        stop: 0.8    rgba(180, 180, 180, 140));
 
-    border: 1px outset rgb(100, 100, 100);
+    border: 1px outset rgb(100, 100, 100, 140);
 
 }
 

--- a/src/resources/css/themes/Rounded/General.css
+++ b/src/resources/css/themes/Rounded/General.css
@@ -224,16 +224,16 @@ QSlider::groove:vertical
 QSlider::groove:vertical
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-            stop: 0     rgb(201, 201, 201),
-            stop: 1.0   rgb(115, 115, 115)
+            stop: 0     rgba(201, 201, 201, 125),
+            stop: 1.0   rgba(115, 115, 115, 125)
             );
 }
 
 QSlider::handle:horizontal
 {
     background: qlineargradient(x1:0, y1:0, x2:1, y2:1,
-        stop: 0      rgb(230, 230, 230),
-        stop: 0.8    rgb(120, 120, 120),
+        stop: 0      rgba(230, 230, 230, 180),
+        stop: 0.8    rgba(120, 120, 120, 180),
         stop: 1      rgba(0, 0, 0, 20));
 
 
@@ -254,8 +254,8 @@ QSlider::handle:horizontal:hover
 QSlider::handle:vertical
 {
     background: qlineargradient(x1:0, y1:0.3, x2:0.7, y2:1,
-        stop: 0      rgb(230, 230, 230),
-        stop: 0.9    rgb(170, 170, 170),
+        stop: 0      rgba(230, 230, 230, 180),
+        stop: 0.9    rgba(170, 170, 170, 180),
         stop: 1      rgba(0, 0, 0, 20));
 
     margin-left: -5px;

--- a/src/resources/css/themes/Volcano_nm/BaseTrack.css
+++ b/src/resources/css/themes/Volcano_nm/BaseTrack.css
@@ -120,8 +120,8 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgba(179, 89, 37, 155);
-    border: 1px outset rgba(137, 69, 29, 180);
+    background: rgba(179, 89, 37, 180);
+    border: 1px outset rgba(137, 69, 29, 200);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Volcano_nm/BaseTrack.css
+++ b/src/resources/css/themes/Volcano_nm/BaseTrack.css
@@ -120,8 +120,8 @@ BaseTrackView[unlighted="true"] QSlider::handle:vertical,    /* track fader hand
 #panSlider::handle:disabled,
 QSlider::handle:vertical:disabled
 {
-    background: rgb(179, 89, 37);
-    border: 1px outset rgb(137, 69, 29);
+    background: rgba(179, 89, 37, 155);
+    border: 1px outset rgba(137, 69, 29, 180);
 }
 
 BaseTrackView[unlighted="true"],                            /* the track */

--- a/src/resources/css/themes/Volcano_nm/General.css
+++ b/src/resources/css/themes/Volcano_nm/General.css
@@ -209,7 +209,7 @@ QSlider::groove
 
 QSlider::handle
 {
-    border: 1px outset #68300F;
+    border: 1px outset rgba(104, 48, 15, 140);
     border-radius: 2px;
 }
 
@@ -217,13 +217,15 @@ QSlider::handle
 PanSlider::handle
 {
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-        stop: 0.0 #FDE5A9,
-        stop: 1.0 #FFB301);
+        stop: 0.0 rgb(253, 229, 169, 140),
+        stop: 1.0 rgb(255, 179, 1, 140));
 }
 
 QSlider::handle:hover
 {
-    background-color: #FDE5A9;
+    background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
+    stop: 0.0 #FDE5A9,
+    stop: 1.0 #FFB301);
     border: 1px outset #68300F;
 }
 
@@ -232,8 +234,8 @@ QSlider::handle:hover
 AudioSlider::handle {
 
     background-color: qlineargradient(x1:0, y1:0, x2:0, y2:1,
-            stop: 0.0 rgba(253, 229, 169, 180),
-            stop: 1.0 rgba(255, 179, 1, 180));
+            stop: 0.0 rgba(253, 229, 169, 140),
+            stop: 1.0 rgba(255, 179, 1, 140));
 }
 
 AudioSlider

--- a/src/resources/css/themes/Volcano_nm/NinjamWindow.css
+++ b/src/resources/css/themes/Volcano_nm/NinjamWindow.css
@@ -25,7 +25,7 @@ NinjamTrackView[horizontal="true"][unlighted="true"]
 
 NinjamTrackView[unlighted="true"][horizontal="true"] QSlider::handle:horizontal
  {
- background: rgb(179, 89, 37);
+ background: rgba(179, 89, 37, 200);
  Border: none;
  }
 


### PR DESCRIPTION
The reason for this PR @elieserdejesus is level meters and peak dB dissappear under the fader handle and sometimes you need to see behind to know what the level is if the handle is blocking the peaks. For example:

![image](https://user-images.githubusercontent.com/15310433/37752361-8e7642d0-2d76-11e8-8a78-0634bd97227f.png)
