### PR TITLE
Merge branch 'develop'

### DIFF
--- a/src/Standalone/MainControllerStandalone.cpp
+++ b/src/Standalone/MainControllerStandalone.cpp
@@ -446,7 +446,8 @@ void MainControllerStandalone::start()
 
     auPluginFinder.reset(new audio::AudioUnitPluginFinder());
 
-    connect(auPluginFinder.data(), &audio::AudioUnitPluginFinder::pluginScanFinished, this, &MainControllerStandalone::addFoundedAudioUnitPlugin);
+    connect(auPluginFinder.data(), &audio::AudioUnitPluginFinder::pluginScanFinished, this,
+                                                &MainControllerStandalone::addFoundedAudioUnitPlugin);
 
 #endif
 

--- a/src/Standalone/PluginFinder.cpp
+++ b/src/Standalone/PluginFinder.cpp
@@ -8,7 +8,8 @@ using audio::PluginDescriptor;
 void PluginFinder::finishScan()
 {
     QProcess::ExitStatus exitStatus = scanProcess.exitStatus();
-    scanProcess.close();
+    if (exitStatus!= QProcess::ExitStatus::CrashExit) // do not try to close an already crashed exit process
+        scanProcess.close();
     bool exitingWithoutError = exitStatus == QProcess::NormalExit;
 
     qCDebug(jtStandalonePluginFinder) << "Closing scan process! exited without error:" << exitingWithoutError;

--- a/src/Standalone/gui/MainWindowStandalone.h
+++ b/src/Standalone/gui/MainWindowStandalone.h
@@ -94,6 +94,9 @@ private:
 
     void initializePluginFinder();
 
+    // standalone settings persistency management
+    void readWindowSettings(bool isWindowMaximized);
+    void writeWindowSettings();
 };
 
 #endif // MAINFRAMEVST_H


### PR DESCRIPTION
- Ensure that standalone window state gets saved restored when maximized as well
- Fix Main Window standalone restore position and size would fail with multiple monitors on OSX and also introduce save restore state high level QT API use.
  Now saving the state allows to persist the toolbars layout as well (i.e. tab bar).
  This new code also does not make low level assumptions on the display and only affects the standalone window to facilitate regression testing.
  Some of this code could be reused in future for the plugin common gui code as well.
- Don't attempt to close a PluginFinder process that has crashed and already exited to avoid hanging and preventing main app to exit.
- Minor line formatting fix in MainControllerStandalone