### PR TITLE
Fix standalone main window position, size and add state persistency. 

### DIFF
--- a/src/Standalone/MainControllerStandalone.cpp
+++ b/src/Standalone/MainControllerStandalone.cpp
@@ -446,7 +446,8 @@ void MainControllerStandalone::start()
 
     auPluginFinder.reset(new audio::AudioUnitPluginFinder());
 
-    connect(auPluginFinder.data(), &audio::AudioUnitPluginFinder::pluginScanFinished, this, &MainControllerStandalone::addFoundedAudioUnitPlugin);
+    connect(auPluginFinder.data(), &audio::AudioUnitPluginFinder::pluginScanFinished, this,
+                                                &MainControllerStandalone::addFoundedAudioUnitPlugin);
 
 #endif
 

--- a/src/Standalone/PluginFinder.cpp
+++ b/src/Standalone/PluginFinder.cpp
@@ -8,7 +8,8 @@ using audio::PluginDescriptor;
 void PluginFinder::finishScan()
 {
     QProcess::ExitStatus exitStatus = scanProcess.exitStatus();
-    scanProcess.close();
+    if (exitStatus!= QProcess::ExitStatus::CrashExit) // do not try to close an already crashed exit process
+        scanProcess.close();
     bool exitingWithoutError = exitStatus == QProcess::NormalExit;
 
     qCDebug(jtStandalonePluginFinder) << "Closing scan process! exited without error:" << exitingWithoutError;

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -486,7 +486,7 @@ void MainWindowStandalone::readWindowSettings(bool isWindowMaximized) {
     QSettings settings(QCoreApplication::organizationName(),
                        QCoreApplication::applicationName());
 
-    QPoint pos = settings.value("pos", QPoint(200, 200)).toPoint();
+    QPoint pos = settings.value("pos", QPoint(50, 50)).toPoint();
     QSize size = settings.value("size", QSize(400, 400)).toSize();
     QByteArray state = settings.value("state", QByteArray())
                                                    .toByteArray();
@@ -501,8 +501,6 @@ void MainWindowStandalone::writeWindowSettings() {
     /* Save position/size of main window */
     QSettings settings(QCoreApplication::organizationName(),
                        QCoreApplication::applicationName());
-
-    QSettings settings(orgName, aName);
 
     settings.setValue("pos", pos());
     settings.setValue("size", size());

--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -483,7 +483,9 @@ void MainWindowStandalone::addChannelsGroup(const QString &groupName)
 }
 
 void MainWindowStandalone::readWindowSettings(bool isWindowMaximized) {
-    QSettings settings;
+    QSettings settings(QCoreApplication::organizationName(),
+                       QCoreApplication::applicationName());
+
     QPoint pos = settings.value("pos", QPoint(200, 200)).toPoint();
     QSize size = settings.value("size", QSize(400, 400)).toSize();
     QByteArray state = settings.value("state", QByteArray())
@@ -496,8 +498,12 @@ void MainWindowStandalone::readWindowSettings(bool isWindowMaximized) {
 }
 
 void MainWindowStandalone::writeWindowSettings() {
-    /* Save postion/size of main window */
-    QSettings settings;
+    /* Save position/size of main window */
+    QSettings settings(QCoreApplication::organizationName(),
+                       QCoreApplication::applicationName());
+
+    QSettings settings(orgName, aName);
+
     settings.setValue("pos", pos());
     settings.setValue("size", size());
     settings.setValue("state", saveState());

--- a/src/Standalone/gui/MainWindowStandalone.h
+++ b/src/Standalone/gui/MainWindowStandalone.h
@@ -94,6 +94,9 @@ private:
 
     void initializePluginFinder();
 
+    // standalone settings persistency management
+    void readWindowSettings(bool isWindowMaximized);
+    void writeWindowSettings();
 };
 
 #endif // MAINFRAMEVST_H

--- a/src/Standalone/main.cpp
+++ b/src/Standalone/main.cpp
@@ -11,6 +11,7 @@
 
 int main(int argc, char* args[] ){
 
+    QApplication::setOrganizationName("Jamtaba");
     QApplication::setApplicationName("JamTaba 2");
     QApplication::setApplicationVersion(APP_VERSION);
 


### PR DESCRIPTION
Tested successfully on both Windows and Mac OS X.
Also features minor source reformating and one hang fix in case PluginFinder crashes. 