### PR TITLE
Do not introduce organization name root based settings to keep compat…

### DIFF
--- a/src/Standalone/gui/MainWindowStandalone.cpp
+++ b/src/Standalone/gui/MainWindowStandalone.cpp
@@ -483,8 +483,7 @@ void MainWindowStandalone::addChannelsGroup(const QString &groupName)
 }
 
 void MainWindowStandalone::readWindowSettings(bool isWindowMaximized) {
-    QSettings settings(QCoreApplication::organizationName(),
-                       QCoreApplication::applicationName());
+    QSettings settings(QCoreApplication::applicationName());
 
     QPoint pos = settings.value("pos", QPoint(50, 50)).toPoint();
     QSize size = settings.value("size", QSize(400, 400)).toSize();
@@ -499,8 +498,7 @@ void MainWindowStandalone::readWindowSettings(bool isWindowMaximized) {
 
 void MainWindowStandalone::writeWindowSettings() {
     /* Save position/size of main window */
-    QSettings settings(QCoreApplication::organizationName(),
-                       QCoreApplication::applicationName());
+    QSettings settings(QCoreApplication::applicationName());
 
     settings.setValue("pos", pos());
     settings.setValue("size", size());

--- a/src/Standalone/main.cpp
+++ b/src/Standalone/main.cpp
@@ -11,7 +11,6 @@
 
 int main(int argc, char* args[] ){
 
-    QApplication::setOrganizationName("Jamtaba");
     QApplication::setApplicationName("JamTaba 2");
     QApplication::setApplicationVersion(APP_VERSION);
 
@@ -29,7 +28,7 @@ int main(int argc, char* args[] ){
     QApplication application(argc, args);
 #endif
 
-    application.setStyle("fusion"); // same visual in all plataforms
+    application.setStyle("fusion"); // same visual in all platforms
 
     controller::MainControllerStandalone mainController(settings, &application);
     mainController.start();


### PR DESCRIPTION
- Do not introduce organization name root based settings to keep compatibility with older settings and code. 
- Fix one comment typo.