### PR TITLE
hiding video channel in local tracks when used

### DIFF
--- a/src/Common/gui/LocalTrackGroupView.cpp
+++ b/src/Common/gui/LocalTrackGroupView.cpp
@@ -53,7 +53,8 @@ void LocalTrackGroupView::setAsVideoChannel()
     setInstrumentIcon(instrumentIcon);
     instrumentsButton->setStyleSheet(QString("margin-left: 0px"));
     instrumentsButton->blockSignals(true);
-    instrumentsButton->setVisible(!peakMeterOnly);
+    instrumentsButton->setVisible(false);
+    xmitButton->setVisible(false);
 
     auto tracks = getTracks<LocalTrackView *>();
     for (auto track : tracks) {


### PR DESCRIPTION
@elieserdejesus I´m proposing hiding completely the video channel in local tracks. The GUI will look the same as previous versions, the cleanest IMO. What do you think?