### PR TITLE
Alternate geolocation server implementation see #1146

### DIFF
--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -432,8 +432,8 @@ geo::Location MainController::getGeoLocation(const QString &ip)
 {
 
     auto sanitizedIp = ninjam::client::maskIP(ip);
-
-    sanitizedIp.replace(ninjam::client::IP_MASK, ".128"); // replace .x (mask) with .128 to generate a valid IP
+    if (!sanitizedIp.isEmpty()) // some servers may not return an ip for user, dont concatenate to ".128" in that case
+        sanitizedIp.replace(ninjam::client::IP_MASK, ".128"); // replace .x (mask) with .128 to generate a valid IP
 
     return ipToLocationResolver->resolve(sanitizedIp, getTranslationLanguage());
 }

--- a/src/Common/geo/WebIpToLocationResolver.cpp
+++ b/src/Common/geo/WebIpToLocationResolver.cpp
@@ -16,6 +16,8 @@
 #include <QPointF>
 #include "log/Logging.h"
 #include "persistence/CacheHeader.h"
+#include <QSettings>
+#include <QApplication>
 
 using geo::WebIpToLocationResolver;
 
@@ -193,11 +195,20 @@ void WebIpToLocationResolver::requestDataFromWebService(const QString &ip, int r
 
     QNetworkRequest request;
 
+    static QString ipApiKey;
+    static QString ipStackKey;
+
+    if (ipApiKey.isEmpty()) {
+        QSettings settings(QCoreApplication::applicationName());
+        ipApiKey = settings.value("ipApiKey", "22f433857895c84347e949db234af11f").toString();
+        ipStackKey = settings.value("ipStackKey", "7dfb5855025fa60f5ce082a4c376091a").toString();
+    }
+
     QString serviceUrl = "http://api.ipapi.com";
-    QString accessKey("22f433857895c84347e949db234af11f");
+    QString accessKey(ipApiKey);
 
     QString alternativeServiceUrl1 = "http://api.ipstack.com/";
-    QString alternativeAccessKey1("7dfb5855025fa60f5ce082a4c376091a");
+    QString alternativeAccessKey1(ipStackKey);
 
 
     QString lang = sanitizeLanguageCode(currentLanguage);

--- a/src/Common/geo/WebIpToLocationResolver.cpp
+++ b/src/Common/geo/WebIpToLocationResolver.cpp
@@ -141,12 +141,12 @@ void WebIpToLocationResolver::replyFinished(QNetworkReply *reply)
         QJsonObject root = doc.object();
         if (!root.contains("country_name")) {
             if (root.contains("error")) {
-                auto error= root["error"].toObject();
+                auto error = root["error"].toObject();
                 auto code = error.contains("code") ? error["code"].toInt() : -1;
-                if (retryCount<MaxServersAlternatives)
+                if (retryCount < MaxServersAlternatives)
                 {
                     qDebug() << "Error " << code << " received, trying alternative server ...";
-                    requestDataFromWebService(ip, retryCount+1);
+                    requestDataFromWebService(ip, retryCount + 1);
                 }
                 else {
                     qCritical() << "All servers failed, no more alternatives available";

--- a/src/Common/geo/WebIpToLocationResolver.cpp
+++ b/src/Common/geo/WebIpToLocationResolver.cpp
@@ -2,6 +2,7 @@
 
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QJsonArray>
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QEventLoop>
@@ -25,6 +26,9 @@ const QString WebIpToLocationResolver::LAT_LONG_CACHE_FILE = "lat_long_cache.bin
 const quint32 WebIpToLocationResolver::COUNTRY_NAMES_CACHE_REVISION = 1;
 const quint32 WebIpToLocationResolver::COUNTRY_CODES_CACHE_REVISION = 1;
 const quint32 WebIpToLocationResolver::LAT_LONG_CACHE_REVISION = 1;
+
+// Alternative servers private implementation strategies
+const int MaxServersAlternatives = 2;
 
 WebIpToLocationResolver::WebIpToLocationResolver(const QDir &cacheDir)
     :currentLanguage("en"), // using english as default language
@@ -120,6 +124,7 @@ void WebIpToLocationResolver::replyFinished(QNetworkReply *reply)
 {
     QString ip = reply->property("ip").toString();
     QString language = reply->property("language").toString();
+    int retryCount = reply->property("retryCount").toInt();
 
     if (language != currentLanguage)
         return; //discard the received data if the language was changed since the last request.
@@ -133,8 +138,23 @@ void WebIpToLocationResolver::replyFinished(QNetworkReply *reply)
 
         QJsonObject root = doc.object();
         if (!root.contains("country_name")) {
-            qCritical() << "The root json object not contains 'country_name'";
-            return;
+            if (root.contains("error")) {
+                auto error= root["error"].toObject();
+                auto code = error.contains("code") ? error["code"].toInt() : -1;
+                if (retryCount<MaxServersAlternatives)
+                {
+                    qDebug() << "Error " << code << " received, trying alternative server ...";
+                    requestDataFromWebService(ip, retryCount+1);
+                }
+                else {
+                    qCritical() << "All servers failed, no more alternatives available";
+                }
+                return;
+            }
+            else {
+                qCritical() << "The root json object not contains 'country_name'";
+                return;
+            }
         }
 
         if (!root.contains("country_code")) {
@@ -167,25 +187,40 @@ void WebIpToLocationResolver::replyFinished(QNetworkReply *reply)
 }
 
 // At moment the current api is http://api.ipapi.com/ (the replacement for Nekudo api). Another option is https://freegeoip.net/json/
-void WebIpToLocationResolver::requestDataFromWebService(const QString &ip)
+void WebIpToLocationResolver::requestDataFromWebService(const QString &ip, int retryCount)
 {
     qCDebug(jtIpToLocation) << "requesting ip " << ip ;
 
     QNetworkRequest request;
-    QString serviceUrl = "http://api.ipapi.com";
 
-    QString accessKey(QStringLiteral("22f433857895c84347e949db234af11f"));
+    QString serviceUrl = "http://api.ipapi.com";
+    QString accessKey("22f433857895c84347e949db234af11f");
+
+    QString alternativeServiceUrl1 = "http://api.ipstack.com/";
+    QString alternativeAccessKey1("7dfb5855025fa60f5ce082a4c376091a");
+
 
     QString lang = sanitizeLanguageCode(currentLanguage);
     if (!canTranslateCountryName(lang))
         lang = "en";
 
-    // URL FORMAT: http://api.ipapi.com/{ip}?access_key={key}&language={lang}
-    request.setUrl(QUrl(QString("%1/%2?access_key=%3&language=%4").arg(serviceUrl, ip, accessKey, lang)));
+    // URL FORMAT: i.e. http://api.ipapi.com/{ip}?access_key={key}&language={lang}
+    switch(retryCount) {
+        case 0:
+            request.setUrl(QUrl(QString("%1/%2?access_key=%3&language=%4")
+                .arg(serviceUrl, ip, accessKey, lang)));
+            break;
+        default:
+            request.setUrl(QUrl(QString("%1/%2?access_key=%3&language=%4")
+                .arg(alternativeServiceUrl1, ip, alternativeAccessKey1, lang)));
+            break;
+    }
 
     QNetworkReply* reply = httpClient.get(request);
     reply->setProperty("ip", QVariant(ip));
     reply->setProperty("language", QVariant(currentLanguage));
+    reply->setProperty("retryCount", retryCount);
+
     QObject::connect(reply, SIGNAL(error(QNetworkReply::NetworkError)), this, SLOT(replyError(QNetworkReply::NetworkError)));
 }
 
@@ -238,7 +273,7 @@ geo::Location WebIpToLocationResolver::resolve(const QString &ip, const QString 
     }
 
     if (!ip.isEmpty()) {
-        requestDataFromWebService(ip);
+        requestDataFromWebService(ip, 0);
     }
     return Location();//empty location, the next request for same ip probabily return from cache
 }

--- a/src/Common/geo/WebIpToLocationResolver.h
+++ b/src/Common/geo/WebIpToLocationResolver.h
@@ -26,7 +26,7 @@ private:
     QMap<QString, QPointF> latLongCache;      // IP => QPointF(latitude, longitude)
     QNetworkAccessManager httpClient;
 
-    void requestDataFromWebService(const QString &ip);
+    void requestDataFromWebService(const QString &ip, int retryCount);
 
     // loading
     void loadCountryCodesFromFile();

--- a/src/Common/ninjam/client/User.cpp
+++ b/src/Common/ninjam/client/User.cpp
@@ -40,16 +40,13 @@ QString ninjam::client::maskIpInUserFullName(const QString &userFullName)
 
 QString ninjam::client::maskIP(const QString &ip)
 {
-    QString maskedIP(ip);
-
     // mask ip if necessary to be compatible with ninjam masked IPs
-    if (!maskedIP.endsWith(ninjam::client::IP_MASK)) { // not masked?
-        auto index = maskedIP.lastIndexOf(".");
-        if (index)
-            maskedIP = maskedIP.left(index) + ninjam::client::IP_MASK; // masking
+    if (!ip.isEmpty() && !ip.endsWith(ninjam::client::IP_MASK)) { // not masked?
+        auto index = ip.lastIndexOf(".");
+        if (index) return ip.left(index) + ninjam::client::IP_MASK; // masking
     }
 
-    return maskedIP;
+    return ip;
 }
 
 bool ninjam::client::ipIsMasked(const QString &ip)


### PR DESCRIPTION
Now enjoy a fallback server with 10000 additional requests per month!
Also fixes empty ip's would create false positive errors during geolocation calculation because sanitizeIp would concatenate ".128" to an empty string now creating an non empty string that will not be skipped.