### PR TITLE
adjusting busy dialog size and font to allow long server names

### DIFF
--- a/src/Common/gui/BusyDialog.ui
+++ b/src/Common/gui/BusyDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>331</width>
-    <height>163</height>
+    <width>364</width>
+    <height>186</height>
    </rect>
   </property>
   <property name="sizePolicy">

--- a/src/resources/css/common/Dialogs.css
+++ b/src/resources/css/common/Dialogs.css
@@ -135,6 +135,7 @@ BusyDialog #labelGif
 BusyDialog > QLabel /* the text appearing in Busy dialog, like "connecting in ninbot.com" */
 {
     font-weight: bold;
+    font-size: 10px;
 }
 
 ChordProgressionCreationDialog QComboBox:focus


### PR DESCRIPTION
Final result:

![image](https://user-images.githubusercontent.com/15310433/49094390-4d6a0f00-f24d-11e8-9f65-dda4e5badc7d.png)

Game theme still crops server name. Added entry to https://github.com/elieserdejesus/JamTaba/issues/1036 