### PR TITLE
Bulk ip lookup in geolocation

### DIFF
--- a/src/Common/geo/IpToLocationResolver.cpp
+++ b/src/Common/geo/IpToLocationResolver.cpp
@@ -10,9 +10,9 @@ using geo::NullIpToLocationResolver;
 Location::Location() :
     countryName("UNKNOWN"),
     countryCode("UNKNOWN"),
+    city("UNKNOWN"),
     latitude(-200),
-    longitude(-200),
-    city("UNKNOWN")
+    longitude(-200)
 {
 
 }
@@ -26,9 +26,9 @@ Location::Location(const QString &country, const QString &countryCode, double la
                    double longitude, const QString &city) :
     countryName(sanitize(country)),
     countryCode(sanitize(countryCode)),
+    city(sanitize(city)),
     latitude(latitude),
-    longitude(longitude),
-    city(sanitize(city))
+    longitude(longitude)
 {
     //
 }

--- a/src/Common/geo/WebIpToLocationResolver.h
+++ b/src/Common/geo/WebIpToLocationResolver.h
@@ -17,7 +17,7 @@ class WebIpToLocationResolver : public IpToLocationResolver
 
 public:
     explicit WebIpToLocationResolver(const QDir &cacheDir);
-    ~WebIpToLocationResolver();
+    ~WebIpToLocationResolver() override;
     geo::Location resolve(const QString &ip, const QString &languageCode) override;
 
 private:

--- a/src/Common/gui/JamRoomViewPanel.cpp
+++ b/src/Common/gui/JamRoomViewPanel.cpp
@@ -169,6 +169,7 @@ void JamRoomViewPanel::updateMap()
         QList<MapMarker> newMarkers;
         for (const auto &user : userInfos) {
             if (!userIsBot(user)) {
+                //TODO Use bulk ip loockup here
                 auto userLocation = mainController->getGeoLocation(user.getIp());
                 if (userLocation.isUnknown())
                     continue; // skip invalid locations

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -2239,6 +2239,7 @@ void MainWindow::translatePublicChatCountryNames()
     if (publicChat) {
         auto connectedUsers = publicChat->getConnectedUsers();
 
+        //TODO use bulk ip loockup here too
         for (const QString &userFullName : connectedUsers) {
             auto ip = ninjam::client::extractUserIP(userFullName);
             publicChat->updateUsersLocation(ip, mainController->getGeoLocation(ip));

--- a/src/Common/gui/widgets/ChatTabWidget.cpp
+++ b/src/Common/gui/widgets/ChatTabWidget.cpp
@@ -67,6 +67,7 @@ void ChatTabWidget::initialize(MainController *mainController, UsersColorsPool *
     this->ninjamColorsPool = colorsPool;
     this->mainController = mainController;
 
+    //TODO use bulk ip loockup here
     connect(mainController, &MainController::ipResolved, [=](const QString &ip){
         mainChat->updateUsersLocation(ip, mainController->getGeoLocation(ip));
     });
@@ -183,6 +184,7 @@ void ChatTabWidget::setConnectedUsersInMainChat(const QStringList &usersNames)
 
     mainChat->setConnectedUsers(usersNames);
 
+    //TODO user bulk ip loockup here
     for (const QString &userFullName : usersNames) {
         auto ip = ninjam::client::extractUserIP(userFullName);
         mainChat->updateUsersLocation(ip, mainController->getGeoLocation(ip));


### PR DESCRIPTION
Both geolocation APIs are supporting bulk ip requests. At moment Jamtaba is requesting one IP per HTTP request. This is contributing to "burn" the free API quota.

Using the bulk ip lookup feature we send a set of ips per request and receive a set of geolocations. This can drastically reduce the free APIs usage.