### PR TITLE
Forcing video max size (fix #1073)

### DIFF
--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -33,7 +33,7 @@ using persistence::LocalInputTrackSettings;
 using controller::MainController;
 
 const quint8 MainController::CAMERA_FPS = 10;
-const QSize MainController::MAX_VIDEO_SIZE(320, 340); // max video width in pixels
+const QSize MainController::MAX_VIDEO_SIZE(320, 240); // max video resolution in pixels
 
 const QString MainController::CRASH_FLAG_STRING = "JamTaba closed without crash :)";
 

--- a/src/Common/MainController.cpp
+++ b/src/Common/MainController.cpp
@@ -24,6 +24,7 @@
 #include <QBuffer>
 #include <QByteArray>
 #include <QDateTime>
+#include <QSize>
 
 using ninjam::client::Service;
 using ninjam::client::ServerInfo;
@@ -32,6 +33,7 @@ using persistence::LocalInputTrackSettings;
 using controller::MainController;
 
 const quint8 MainController::CAMERA_FPS = 10;
+const QSize MainController::MAX_VIDEO_SIZE(320, 340); // max video width in pixels
 
 const QString MainController::CRASH_FLAG_STRING = "JamTaba closed without crash :)";
 
@@ -101,7 +103,11 @@ long MainController::getTotalUploadTransferRate() const
 
 void MainController::setVideoProperties(const QSize &resolution)
 {
-    videoEncoder.setVideoResolution(resolution);
+    QSize bestResolution(resolution);
+    if (resolution.width() > MainController::MAX_VIDEO_SIZE.width())
+         bestResolution = MainController::MAX_VIDEO_SIZE;
+
+    videoEncoder.setVideoResolution(bestResolution);
     videoEncoder.setVideoFrameRate(CAMERA_FPS);
 }
 

--- a/src/Common/MainController.h
+++ b/src/Common/MainController.h
@@ -302,6 +302,8 @@ public:
 
     void setPublicChatActivated(bool activated);
 
+    const static QSize MAX_VIDEO_SIZE;
+
 signals:
     void ipResolved(const QString &ip);
     void themeChanged();

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -421,7 +421,7 @@ QImage MainWindow::pickCameraFrame() const
         // have only big resolutions, and we have problems sensing big resolution videos to ninjam servers.
 
         if (frame.width() > MainController::MAX_VIDEO_SIZE.width())
-            return frame.scaled(mainController->getVideoResolution(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+            return frame.scaled(mainController->getVideoResolution(), Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
         return frame;
     }

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -243,6 +243,7 @@ void MainWindow::initializeCamera(const QString &cameraDeviceName)
         QSize bestResolution = getBestCameraResolution(resolutions);
         settings.setResolution(bestResolution);
         camera->setViewfinderSettings(settings);
+        qDebug() << "Setting camera viewFinder resolution to " << camera->viewfinderSettings().resolution();
 
         //getBestSupportedFrameRate();
 
@@ -415,8 +416,15 @@ bool MainWindow::cameraIsActivated() const
 QImage MainWindow::pickCameraFrame() const
 {
     if (videoFrameGrabber && cameraView) {
-        QImage frame = videoFrameGrabber->grab(cameraView->size());
+        auto frame = videoFrameGrabber->grab();
         cameraView->setCurrentFrame(frame);
+
+        // scale the grabed frame if is bigger than MAX_VIDEO_SIZE. This is necessary because some cameras
+        // have only big resolutions, and we have problems sensing big resolution videos to ninjam servers.
+
+        if (frame.width() > MainController::MAX_VIDEO_SIZE.width())
+            return frame.scaled(mainController->getVideoResolution(), Qt::KeepAspectRatio, Qt::SmoothTransformation);
+
         return frame;
     }
 

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -266,18 +266,16 @@ void MainWindow::initializeCamera(const QString &cameraDeviceName)
 
 QSize MainWindow::getBestCameraResolution(const QList<QSize> resolutions) const
 {
-    const static quint16 PREFERRED_WIDTH = 320;
-
-    auto bestResolution = QSize(PREFERRED_WIDTH, 240);
+    auto bestResolution = MainController::MAX_VIDEO_SIZE;
 
     if (!resolutions.isEmpty()) {
         auto lowestResolution = resolutions.first();
-        if (lowestResolution.width() > PREFERRED_WIDTH) { // using the lowest resolution in big resolution cams
+        if (lowestResolution.width() > MainController::MAX_VIDEO_SIZE.width()) { // using the lowest resolution in big resolution cams
             bestResolution = lowestResolution;
         }
         else { // pick the first resolution where width < 320
             for (int i = resolutions.size() - 1; i >= 0;  --i) {
-                if (resolutions.at(i).width() <= PREFERRED_WIDTH) {
+                if (resolutions.at(i).width() <= MainController::MAX_VIDEO_SIZE.width()) {
                     bestResolution = resolutions.at(i);
                     break;
                 }

--- a/src/Common/video/VideoFrameGrabber.h
+++ b/src/Common/video/VideoFrameGrabber.h
@@ -46,7 +46,7 @@ public:
 
     bool present(const QVideoFrame& frame) override;
 
-    inline QImage grab(const QSize &size) override
+    inline QImage grab(const QSize &size = QSize()) override
     {
         Q_UNUSED(size);
         return lastImage;


### PR DESCRIPTION
Forcing video max size to 320x240 if camera lowest resolution is bigger. 

Tested in ninbot simulating a very big camera resolution and is working, no more disconnections.