### PR TITLE
centering country names when hovering map with mouse pointer

### DIFF
--- a/src/Common/gui/widgets/MapWidget.cpp
+++ b/src/Common/gui/widgets/MapWidget.cpp
@@ -394,7 +394,7 @@ void MapWidget::drawCountriesLegend(QPainter &p)
     auto legendHeight = (flagSize.height() + TEXT_MARGIM) * uniqueCountryMarkers.size() + TEXT_MARGIM;
 
     QSizeF legendSize(legendWidth, legendHeight);
-    QPointF legendTopLeft(width() - legendSize.width() - TEXT_MARGIM, TEXT_MARGIM);
+    QPointF legendTopLeft((width() - legendSize.width() - TEXT_MARGIM) / 2, TEXT_MARGIM);
     QRectF legendRect(legendTopLeft, legendSize);
 
     // draw the transparent background

--- a/src/Common/gui/widgets/MapWidget.cpp
+++ b/src/Common/gui/widgets/MapWidget.cpp
@@ -394,7 +394,7 @@ void MapWidget::drawCountriesLegend(QPainter &p)
     auto legendHeight = (flagSize.height() + TEXT_MARGIM) * uniqueCountryMarkers.size() + TEXT_MARGIM;
 
     QSizeF legendSize(legendWidth, legendHeight);
-    QPointF legendTopLeft((width() - legendSize.width() - TEXT_MARGIM) / 2, TEXT_MARGIM);
+    QPointF legendTopLeft(width()/2 - legendSize.width()/2, height()/2 - legendSize.height()/2);
     QRectF legendRect(legendTopLeft, legendSize);
 
     // draw the transparent background


### PR DESCRIPTION
I think it's cleaner this way if rooms are crowded in small screens or as plugin. Avoiding most overlaps this way.

![image](https://user-images.githubusercontent.com/15310433/53364763-4622d200-391e-11e9-8e96-f71a0270e286.png)
