### PR TITLE
battery meter (Windows only)

### DIFF
--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -2083,17 +2083,25 @@ void MainWindow::timerEvent(QTimerEvent *)
     if (now - lastPerformanceMonitorUpdate >= PERFORMANCE_MONITOR_REFRESH_TIME) {
 
         if (performanceMonitorLabel) {
-            QString string;
 
-                if (performanceMonitor->getMemmoryUsed() > 60) //memory meter only active if memory usage is <60%
-                    string = string + QString("MEM: %1%").arg(performanceMonitor->getMemmoryUsed());
+                   auto memmoryUsed = performanceMonitor->getMemmoryUsed();
+                   auto batteryUsed = performanceMonitor->getBatteryUsed();
 
-                if (performanceMonitor->getBatteryUsed() < 255) //Battery meter active only if battery is available
-                    string = string + QString(" BAT: %1%").arg(performanceMonitor->getBatteryUsed());
+                   bool showMemmory = memmoryUsed > 60; //memory meter only active if memory usage is <60%
+                   bool showBattery = batteryUsed < 255; //Battery meter active only if battery is available
 
-            performanceMonitorLabel->setText(string);
+                   QString string;
+                   if (showMemmory)
+                       string += QString("MEM: %1%").arg(performanceMonitor->getMemmoryUsed());
 
-        }
+                   if (showBattery)
+                       string += QString(" BAT: %1%").arg(performanceMonitor->getBatteryUsed());
+
+                   performanceMonitorLabel->setText(string);
+
+                   performanceMonitorLabel->setVisible(showMemmory || showBattery);
+
+               }
 
         lastPerformanceMonitorUpdate = now;
     }

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -2086,7 +2086,7 @@ void MainWindow::timerEvent(QTimerEvent *)
             QString string;
 
                 if (performanceMonitor->getMemmoryUsed() > 60) //memory meter only active if memory usage is <60%
-                    string = string + QString(" MEM: %1%").arg(performanceMonitor->getMemmoryUsed());
+                    string = string + QString("MEM: %1%").arg(performanceMonitor->getMemmoryUsed());
 
                 if (performanceMonitor->getBatteryUsed() < 255) //Battery meter active only if battery is available
                     string = string + QString(" BAT: %1%").arg(performanceMonitor->getBatteryUsed());

--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -2082,8 +2082,18 @@ void MainWindow::timerEvent(QTimerEvent *)
     qint64 now = QDateTime::currentMSecsSinceEpoch();
     if (now - lastPerformanceMonitorUpdate >= PERFORMANCE_MONITOR_REFRESH_TIME) {
 
-        if (performanceMonitorLabel)
-            performanceMonitorLabel->setText(QString("MEM: %1%").arg(performanceMonitor->getMemmoryUsed()));
+        if (performanceMonitorLabel) {
+            QString string;
+
+                if (performanceMonitor->getMemmoryUsed() > 60) //memory meter only active if memory usage is <60%
+                    string = string + QString(" MEM: %1%").arg(performanceMonitor->getMemmoryUsed());
+
+                if (performanceMonitor->getBatteryUsed() < 255) //Battery meter active only if battery is available
+                    string = string + QString(" BAT: %1%").arg(performanceMonitor->getBatteryUsed());
+
+            performanceMonitorLabel->setText(string);
+
+        }
 
         lastPerformanceMonitorUpdate = now;
     }

--- a/src/Common/performance/PerformanceMonitor.h
+++ b/src/Common/performance/PerformanceMonitor.h
@@ -18,6 +18,7 @@ public:
     ~PerformanceMonitor();
     //int getMemmoryUsage();
     int getMemmoryUsed();
+    int getBatteryUsed();
     //double getCpuUsage();
     //double getTotalCpuUsage();
 

--- a/src/Common/performance/WindowsPerformanceMonitor.cpp
+++ b/src/Common/performance/WindowsPerformanceMonitor.cpp
@@ -93,10 +93,11 @@ int PerformanceMonitor::getMemmoryUsed(){
 
 int PerformanceMonitor::getBatteryUsed(){
 
+    //http://www.cplusplus.com/forum/beginner/72594/
         SYSTEM_POWER_STATUS status; // note not LPSYSTEM_POWER_STATUS
     GetSystemPowerStatus(&status);
 
-    int life = status.BatteryLifePercent;
+    int life = status.BatteryLifePercent; //if value is 255 that means unknown
     //int BTime = status.BatteryLifeTime;
 
 return life;

--- a/src/Common/performance/WindowsPerformanceMonitor.cpp
+++ b/src/Common/performance/WindowsPerformanceMonitor.cpp
@@ -4,79 +4,18 @@
 #include "Windows.h"
 #include "psapi.h"
 
-//http://hackage.haskell.org/package/criterion-1.1.0.0/src/cbits/time-windows.c
-
-PerformanceMonitor::PerformanceMonitor(){
-/*
-    HANDLE thisProcessHande = GetCurrentProcess();
-    SYSTEM_INFO sysInfo;
-    BOOL runningInWow64 = false;
-    IsWow64Process(thisProcessHande, &runningInWow64);
-    if(runningInWow64){
-        GetNativeSystemInfo(&sysInfo);
-    }
-    else{
-        GetSystemInfo(&sysInfo);
-    }
-    this->processorsCount = sysInfo.dwNumberOfProcessors;
-*/
-}
-
-PerformanceMonitor::~PerformanceMonitor(){
+PerformanceMonitor::PerformanceMonitor()
+{
 
 }
 
-/*
-//http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
-double PerformanceMonitor::getCpuUsage(){
-    static ULARGE_INTEGER lastCPU;
-    static ULARGE_INTEGER lastSysCPU;
-    static ULARGE_INTEGER lastUserCPU;
-    static HANDLE thisProcessHande = GetCurrentProcess();
+PerformanceMonitor::~PerformanceMonitor()
+{
 
-    FILETIME ftime, fsys, fuser;
-    ULARGE_INTEGER now, sys, user;
-    double percent;
-
-    GetSystemTimeAsFileTime(&ftime);
-    memcpy(&now, &ftime, sizeof(FILETIME));
-
-    if(GetProcessTimes(thisProcessHande, &ftime, &ftime, &fsys, &fuser)){
-        memcpy(&sys, &fsys, sizeof(FILETIME));
-        memcpy(&user, &fuser, sizeof(FILETIME));
-        percent = (sys.QuadPart - lastSysCPU.QuadPart) +
-                (user.QuadPart - lastUserCPU.QuadPart);
-        percent /= (now.QuadPart - lastCPU.QuadPart);
-        percent /= this->processorsCount;
-        lastCPU = now;
-        lastUserCPU = user;
-        lastSysCPU = sys;
-        //qInfo() << "percent:" << percent * 100;
-        return percent * 100;
-    }
-    return 0;
 }
 
-int PerformanceMonitor::getMemmoryUsage(){
-
-    //http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
-    PROCESS_MEMORY_COUNTERS_EX pmc;
-    bool result = GetProcessMemoryInfo(GetCurrentProcess(), (PPROCESS_MEMORY_COUNTERS)&pmc, sizeof(pmc));
-    static const int DIVIDER = 1024 * 1024;
-    if(result){
-        //        qInfo() << "PrivateUsage:" << pmc.PrivateUsage/1024/1024;
-        //        qInfo() << "WorkingSetSize:" << pmc.WorkingSetSize/1024/1024;
-        //        qInfo() << "------------------------------";
-        return pmc.PrivateUsage/DIVIDER;
-    }
-    else{
-        qWarning() << "Can't get memory usage! GetProcessMemoryInfo fail!";
-    }
-    return 0;
-}
-*/
-
-int PerformanceMonitor::getMemmoryUsed(){
+int PerformanceMonitor::getMemmoryUsed()
+{
 
     //http://stackoverflow.com/questions/63166/how-to-determine-cpu-and-memory-consumption-from-inside-a-process
     MEMORYSTATUSEX memInfo;
@@ -91,14 +30,14 @@ int PerformanceMonitor::getMemmoryUsed(){
     return 0;
 }
 
-int PerformanceMonitor::getBatteryUsed(){
+int PerformanceMonitor::getBatteryUsed()
+{
 
     //http://www.cplusplus.com/forum/beginner/72594/
         SYSTEM_POWER_STATUS status; // note not LPSYSTEM_POWER_STATUS
     GetSystemPowerStatus(&status);
 
     int life = status.BatteryLifePercent; //if value is 255 that means unknown
-    //int BTime = status.BatteryLifeTime;
 
 return life;
 }

--- a/src/Common/performance/WindowsPerformanceMonitor.cpp
+++ b/src/Common/performance/WindowsPerformanceMonitor.cpp
@@ -90,3 +90,14 @@ int PerformanceMonitor::getMemmoryUsed(){
     }
     return 0;
 }
+
+int PerformanceMonitor::getBatteryUsed(){
+
+        SYSTEM_POWER_STATUS status; // note not LPSYSTEM_POWER_STATUS
+    GetSystemPowerStatus(&status);
+
+    int life = status.BatteryLifePercent;
+    //int BTime = status.BatteryLifeTime;
+
+return life;
+}


### PR DESCRIPTION
Hi @elieserdejesus . I did this little PR to allow battery percentage when portable hardware is used.

 Additionally the memory meter appears only when using more than 60% and battery meter is shown only if a battery is available.

![image](https://user-images.githubusercontent.com/15310433/78394997-04556800-75c3-11ea-9d07-b7fdd95a053d.png)

The only problem I found was this little empty label when nothing is shown:

![image](https://user-images.githubusercontent.com/15310433/78394016-3a91e800-75c1-11ea-984e-ea245ec0c3c9.png)

what do you think?

