### PR TITLE
fixing crash when user = bot name 'booga'

### DIFF
--- a/src/Common/ninjam/client/Service.cpp
+++ b/src/Common/ninjam/client/Service.cpp
@@ -207,7 +207,6 @@ QStringList Service::buildBotNamesList()
     names.append(QStringLiteral("localhost"));
     names.append(QStringLiteral("dojcbot"));
     names.append(QStringLiteral("DOJCbot"));
-    names.append(QStringLiteral("booga"));
     names.append(QStringLiteral("server@server"));
     return names;
 }


### PR DESCRIPTION
Jamtaba is crashing when user inside room is named as bot 'booga'.
