### PR TITLE
Videochannel usage won't xmit audio data on ch2

### DIFF
--- a/src/Common/gui/LocalTrackGroupView.cpp
+++ b/src/Common/gui/LocalTrackGroupView.cpp
@@ -66,6 +66,7 @@ void LocalTrackGroupView::setAsVideoChannel()
     instrumentsButton->setStyleSheet(QString("margin-left: 0px"));
     instrumentsButton->blockSignals(true);
     instrumentsButton->setVisible(!peakMeterOnly);
+    xmitButton->setChecked(false);
     xmitButton->setVisible(false);
 
     auto tracks = getTracks<LocalTrackView *>();


### PR DESCRIPTION
ATM activating camera creates a Videochannel  on channel 2 and simultaneously silent audio data is sent to the server. This means more bandwidth is used. 

Also if you record locally a silent 2nd audio channel is created. This is not optimal.

This PR fixes this issue creating a clean video channel