### PR TITLE
bots subtracted from maxusers in jamroomview

### DIFF
--- a/src/Common/loginserver/LoginService.cpp
+++ b/src/Common/loginserver/LoginService.cpp
@@ -188,6 +188,7 @@ RoomInfo LoginService::buildRoomInfoFromJson(const QJsonObject &jsonObject)
     auto name =  getServerName(serverNameText);
     int port = getServerPort(serverNameText);
     int maxUsers = jsonObject.contains("user_max") ? jsonObject["user_max"].toString().toInt() : getServerGuessedMaxUsers(name, port);
+    if (name.contains("ninbot") || name.contains("ninjamer")) maxUsers--; // ugly hack to get bots subtracted from maxusers in jamroomview
     auto streamLink = jsonObject.contains("stream") ? jsonObject["stream"].toString() : QString("");
     int bpi = jsonObject.contains("bpi") ? jsonObject["bpi"].toString().toInt() : 16;
     int bpm = jsonObject.contains("bpm") ? jsonObject["bpm"].toString().toInt() : 120;

--- a/src/Common/ninjam/client/Service.cpp
+++ b/src/Common/ninjam/client/Service.cpp
@@ -198,16 +198,7 @@ QStringList Service::buildBotNamesList()
 {
     QStringList names;
     names.append(QStringLiteral("Jambot"));
-    names.append(QStringLiteral("ninjamer.com"));
-    names.append(QStringLiteral("ninbot"));
-    names.append(QStringLiteral("ninbot.com"));
-    names.append(QStringLiteral("MUTANTLAB"));
-    names.append(QStringLiteral("mutantlab.com"));
-    names.append(QStringLiteral("LiveStream"));
-    names.append(QStringLiteral("localhost"));
-    names.append(QStringLiteral("dojcbot"));
-    names.append(QStringLiteral("DOJCbot"));
-    names.append(QStringLiteral("booga"));
+    names.append(QStringLiteral("ninbot_"));
     names.append(QStringLiteral("server@server"));
     return names;
 }


### PR DESCRIPTION
- [x] change bot name "ninbot" to "ninbot_"

ugly hack but working :/

now all ninbot and ninjamer servers show the correct maxusers value.

TODO: delete obsolete bot detection code.