### PR TITLE
Fix for Windows crash related to MIDI clock sync

### DIFF
--- a/src/Common/midi/RtMidiDriver.cpp
+++ b/src/Common/midi/RtMidiDriver.cpp
@@ -217,8 +217,13 @@ void RtMidiDriver::consumeMessagesFromStream(RtMidiIn *stream, int deviceIndex, 
 
 void RtMidiDriver::sendMessageToOutputs(const std::vector<unsigned char> message) const {
     for (auto stream : midiOutStreams) {
-        if (stream->isPortOpen())
+        if (!stream->isPortOpen()) return;
+        try {
             stream->sendMessage(&message);
+        } catch (RtMidiError &e) {
+            qCritical() << "Error sending midi message to output " << QString::fromStdString(e.getMessage());
+            stream->closePort();
+        }
     }
 }
 


### PR DESCRIPTION
### Purpose

This is a potential fix for a crash on Windows related to MIDI clock sync output

### Summary

* Wrap message send in a try/catch and disconnect port if an exception is thrown

### Additional Notes

⚠️ **I need help testing this** - I am unable to build Jamtaba in Windows. Although this fix is based on best available information from crash logs, it has not been proven to fix the issue.

**Repro Steps:**

1. Set up MIDI clock sync in the current standalone release version of Jamtaba on Windows, so clock is being sent to a hardware device over USB
2. Join a server or host one locally
3. Disconnect the hardware device that is receiving MIDI clock

This should instantly produce a crash. The fix I've implemented here in theory should prevent the crash. RtMidi does not appear to have any mechanisms for determining if a MIDI output has been disconnected, but if the `sendMessage` fails, it will throw an exception. This will catch the exception and close the port so it will not try to send any more messages in the future. All of the output ports will be reinitialized when preferences are next changed or if Jamtaba is restarted.

