### PR TITLE
fix midi sync not working at restart

### DIFF
--- a/src/Standalone/gui/PreferencesDialogStandalone.cpp
+++ b/src/Standalone/gui/PreferencesDialogStandalone.cpp
@@ -471,11 +471,11 @@ void PreferencesDialogStandalone::accept()
     for (auto check : syncBoxes)
         syncOutputsStatus.append(check->isChecked());
 
-    PreferencesDialog::accept();
-
     emit ioPreferencesChanged(midiInputsStatus, syncOutputsStatus,
                               selectedAudioInputDevice, selectedAudioOutputDevice,
                               firstIn, lastIn, firstOut, lastOut);
+
+    PreferencesDialog::accept();
 }
 
 void PreferencesDialogStandalone::populateVstTab()


### PR DESCRIPTION
ATM standalone version's midi sync out is not working unless you go to sync preferences and click ok. This PR fixes that.