### PR TITLE
Fix QPainterPath build error with qt5.15

### DIFF
--- a/src/Common/gui/chat/ChatMessagePanel.h
+++ b/src/Common/gui/chat/ChatMessagePanel.h
@@ -4,6 +4,7 @@
 #include <QFrame>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+#include <QtGui/QPainterPath>
 
 namespace Ui {
 class ChatMessagePanel;

--- a/src/Common/gui/intervalProgress/IntervalProgressDisplay.h
+++ b/src/Common/gui/intervalProgress/IntervalProgressDisplay.h
@@ -3,6 +3,7 @@
 
 #include <QFrame>
 #include <QScopedPointer>
+#include <QPainterPath>
 
 class QResizeEvent;
 class QPaintEvent;

--- a/src/Common/gui/intervalProgress/PiePaintStrategy.cpp
+++ b/src/Common/gui/intervalProgress/PiePaintStrategy.cpp
@@ -1,4 +1,5 @@
 #include "IntervalProgressDisplay.h"
+#include <QPainterPath>
 #include <QPainter>
 
 void IntervalProgressDisplay::PiePaintStrategy::paint(QPainter &p, const PaintContext &context, const PaintColors &colors)

--- a/src/Standalone/gui/LocalTrackViewStandalone.h
+++ b/src/Standalone/gui/LocalTrackViewStandalone.h
@@ -10,6 +10,7 @@
 #include <QPushButton>
 #include <QLabel>
 #include <QSpacerItem>
+#include <QPainterPath>
 
 class LocalTrackViewStandalone : public LocalTrackView
 {


### PR DESCRIPTION
Qt 5.15 requires explicit #include for QPainterPath.
https://github.com/elieserdejesus/JamTaba/issues/1413

This causes JamTaba build to fail.
see:  https://wiki.debian.org/qa.debian.org/FTBFS

This PR allows building under Qt5.15 but does not break building under earlier Qt 5.11.