### PR TITLE
#1423 The camera should be on by default

### DIFF
--- a/src/Common/gui/MainWindow.cpp
+++ b/src/Common/gui/MainWindow.cpp
@@ -389,7 +389,7 @@ void MainWindow::initializeCameraWidget()
 
         if (!cameraView) {
             QIcon webcamIcon = IconFactory::createWebcamIcon(tintColor);
-            cameraView = new VideoWidget(this, webcamIcon, false);
+            cameraView = new VideoWidget(this, webcamIcon, true);
             cameraView->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Maximum);
             cameraView->setMaximumHeight(136);
 


### PR DESCRIPTION
This changes the camera widget default behaviour to use the camera by default, as discussed in [this issue](https://github.com/elieserdejesus/JamTaba/issues/1423).